### PR TITLE
WriteConcern is not taken into account when saving domain instance classes through GormInstanceApi

### DIFF
--- a/spring-datastore-mongo/src/main/groovy/org/springframework/datastore/mapping/mongo/engine/MongoEntityPersister.java
+++ b/spring-datastore-mongo/src/main/groovy/org/springframework/datastore/mapping/mongo/engine/MongoEntityPersister.java
@@ -360,7 +360,13 @@ public class MongoEntityPersister extends NativeEntryEntityPersister<DBObject, O
 
                 DBCollection dbCollection = con.getCollection(collectionName);
                 nativeEntry.put(MONGO_ID_FIELD, storeId);
+MongoSession mongoSession = (MongoSession) session;
+if (mongoSession.getWriteConcern() == null) {
                 dbCollection.insert(nativeEntry);
+} else {
+                dbCollection.insert(nativeEntry, mongoSession.getWriteConcern());
+                }
+
                 return nativeEntry.get(MONGO_ID_FIELD);
             }
         });


### PR DESCRIPTION
Make sure the WriteConcern is taken into account when calling "save()" from domain class instances through GormInstanceApi
