### PR TITLE
Fix GPMONGODB-131

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -616,8 +616,10 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
         T tmp = null;
         final NativeEntryModifyingEntityAccess entityAccess = (NativeEntryModifyingEntityAccess) createEntityAccess(persistentEntity, obj, tmp);
 
+		String generatorType = ((Property)getMappingContext().getMappingFactory().createMappedForm(persistentEntity.getIdentity())).getGenerator();
+		
         K k = readObjectIdentifier(entityAccess, persistentEntity.getMapping());
-        boolean isUpdate = k != null;
+		boolean isUpdate = k != null;
         if (isUpdate && !getSession().isDirty(obj)) {
             return (Serializable) k;
         }
@@ -626,11 +628,29 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
 
         String family = getEntityFamily();
         SessionImplementor<Object> si = (SessionImplementor<Object>) session;
+		
+		if (isUpdate) {
+			tmp = (T) si.getCachedEntry(persistentEntity, (Serializable) k);
+            if (tmp == null) {
+                tmp = getFromTPCache(persistentEntity, (Serializable) k);
+                if (tmp == null) {
+                    tmp = retrieveEntry(persistentEntity, family, (Serializable) k);
+                }
+            }
+            if (tmp == null) {
+				if (generatorType=="assigned") {
+					isUpdate = false;
+                }
+				tmp = createNewEntry(family);
+			}
+		} else {
+			tmp = createNewEntry(family);
+		}
+		
         if (!isUpdate) {
-            tmp = createNewEntry(family);
-
-            k = generateIdentifier(persistentEntity, tmp);
-
+			if (generatorType!="assigned")
+				k = generateIdentifier(persistentEntity, tmp);
+			
             cacheNativeEntry(persistentEntity, (Serializable) k, tmp);
 
             pendingOperation = new PendingInsertAdapter<T, K>(persistentEntity, k, tmp, entityAccess) {
@@ -642,17 +662,6 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
             entityAccess.setProperty(entityAccess.getIdentifierName(), k);
         }
         else {
-            tmp = (T) si.getCachedEntry(persistentEntity, (Serializable) k);
-            if (tmp == null) {
-                tmp = getFromTPCache(persistentEntity, (Serializable) k);
-                if (tmp == null) {
-                    tmp = retrieveEntry(persistentEntity, family, (Serializable) k);
-                }
-            }
-            if (tmp == null) {
-                tmp = createNewEntry(family);
-            }
-
             final T finalTmp = tmp;
             final K finalK = k;
             pendingOperation = new PendingUpdateAdapter<T, K>(persistentEntity, finalK, finalTmp, entityAccess) {

--- a/grails-datastore-mongo/src/test/groovy/org/grails/datastore/mapping/mongo/StringIdTests.groovy
+++ b/grails-datastore-mongo/src/test/groovy/org/grails/datastore/mapping/mongo/StringIdTests.groovy
@@ -43,9 +43,58 @@ class StringIdTests extends AbstractMongoTest {
         te = session.retrieve(MongoStringIdEntity, te.id)
         assert te == null
     }
+
+    @Test
+    void testAssignedStringId() {
+        md.mappingContext.addPersistentEntity(MongoAssignedStringIdEntity)
+
+        MongoSession session = md.connect()
+
+        session.nativeInterface.dropDatabase()
+
+        def te = new MongoAssignedStringIdEntity(name:"Bob")
+		te.id = "bob1"
+
+        session.persist te
+        session.flush()
+
+        assert te != null
+		assert te.id == "bob1"
+
+        session.clear()
+        te = session.retrieve(MongoAssignedStringIdEntity, te.id)
+
+        assert te != null
+        assert te.name == "Bob"
+
+        te.name = "Fred"
+        session.persist(te)
+        session.flush()
+        session.clear()
+
+        te = session.retrieve(MongoAssignedStringIdEntity, te.id)
+        assert te != null
+        assert te.id == "bob1"
+        assert te.name == 'Fred'
+
+        session.delete te
+        session.flush()
+
+        te = session.retrieve(MongoAssignedStringIdEntity, te.id)
+        assert te == null
+    }
 }
 
 class MongoStringIdEntity {
     String id
     String name
+}
+
+class MongoAssignedStringIdEntity {
+    String id
+    String name
+	
+	static mapping = {
+		id generator:"assigned"
+	}
 }


### PR DESCRIPTION
I know this isn't the best solution as it hits the database when inserting a new assigned id document or record.  This could have implications for the other projects as well, but is only activated when static mapping = { id generator:'assigned' } is used.
