### PR TITLE
remove last redis plugin dependency in redis-gorm

### DIFF
--- a/grails-plugins/redis/RedisGormGrailsPlugin.groovy
+++ b/grails-plugins/redis/RedisGormGrailsPlugin.groovy
@@ -28,7 +28,7 @@ class RedisGormGrailsPlugin {
 
     def version = "1.0.0.M8"
     def grailsVersion = "1.3.4 > *"
-    def loadAfter = ['domainClass', 'hibernate', 'services', 'cloudFoundry', 'redis']
+    def loadAfter = ['domainClass', 'hibernate', 'services', 'cloudFoundry']
     def observe = ['services', 'domainClass']
     
     def author = "Graeme Rocher"


### PR DESCRIPTION
Sorry, I missed one dependency on the base redis plugin in redis-gorm (pull request #27).  This makes it so that redis-gorm doesn't want redis to get loaded first.

This is necessary as I actually want redis to load after redis-gorm so that I can potentially use the redis-gorm data source if it's installed.
