### PR TITLE
Can't use custom typed fields in embedded classes

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -1034,7 +1034,8 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
                     setEntryValue(embeddedEntry, getPropertyKey(persistentProperty), embeddedEntityAccess.getProperty(persistentProperty.getName()));
                 }
                 else if (persistentProperty instanceof Custom) {
-                    handleCustom(association, embeddedEntityAccess, embeddedEntry);
+                    Custom custom = (Custom)persistentProperty;
+                    handleCustom(custom, embeddedEntityAccess, embeddedEntry);
                 }
                 else if (persistentProperty instanceof Association) {
                     if(persistentProperty instanceof Embedded) {


### PR DESCRIPTION
Simple fix to permit custom typed fields to work properly in embedded classes.
