### PR TITLE
Add ObjectId and DBObject as simple types for mongo

### DIFF
--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoMappingContext.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoMappingContext.java
@@ -20,11 +20,6 @@ import org.grails.datastore.mapping.document.config.DocumentMappingContext;
 import org.grails.datastore.mapping.document.config.DocumentPersistentEntity;
 import org.grails.datastore.mapping.model.*;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Models a {@link org.grails.datastore.mapping.model.MappingContext} for Mongo.
  *


### PR DESCRIPTION
One of the things I first ran into with the mongo gorm plugin was the lack of support for mapping fields of type 'ObjectId' or 'DBObject' without defining a custom type mapping.  This pull request adds these types as simple types so the mapping will automatically handle them.  It would be handy.
