### PR TITLE
NPE check fix

### DIFF
--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
@@ -603,7 +603,7 @@ public class MongoEntityPersister extends NativeEntryEntityPersister<DBObject, O
 
     protected void checkVersion(final EntityAccess ea, final DBObject previous,
                                 final PersistentEntity persistentEntity, final Object key) {
-        Object oldVersion = previous.get("version");
+        Object oldVersion = previous != null ? previous.get("version") : null;
         Object currentVersion = ea.getProperty("version");
         if (Number.class.isAssignableFrom(ea.getPropertyType("version"))) {
             oldVersion = oldVersion != null ? ((Number)oldVersion).longValue() : oldVersion;


### PR DESCRIPTION
...ng/mongo/engine/MongoEntityPersister.java

There's no check that the 'previous' object being passed in is not null.

I've been getting errors on this for months now, and figured sending a patch back 
might help raise this to someone's attention.

The fact that something is passing in a null might be a bigger issue, 
or it may not be - I'm not sure.  But null checking needs to happen here, 
and possible on line 607 (the ea.getProperty) as well.
