### PR TITLE
Fix GPMONGODB-224, load and delete events

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityPersister.java
@@ -19,15 +19,9 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+import org.grails.datastore.mapping.engine.event.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.grails.datastore.mapping.core.Session;
-import org.grails.datastore.mapping.engine.event.PostDeleteEvent;
-import org.grails.datastore.mapping.engine.event.PostInsertEvent;
-import org.grails.datastore.mapping.engine.event.PostLoadEvent;
-import org.grails.datastore.mapping.engine.event.PostUpdateEvent;
-import org.grails.datastore.mapping.engine.event.PreInsertEvent;
-import org.grails.datastore.mapping.engine.event.PreLoadEvent;
-import org.grails.datastore.mapping.engine.event.PreUpdateEvent;
 import org.grails.datastore.mapping.model.MappingContext;
 import org.grails.datastore.mapping.model.PersistentEntity;
 import org.grails.datastore.mapping.proxy.ProxyFactory;
@@ -161,9 +155,6 @@ public abstract class EntityPersister implements Persister {
             return null;
         }
 
-        publisher.publishEvent(new PostLoadEvent(session.getDatastore(),
-                entity, new EntityAccess(entity, o)));
-
         return o;
     }
 
@@ -236,7 +227,7 @@ public abstract class EntityPersister implements Persister {
     }
 
    /**
-    * Fire the beforeUpdate even on an entityAccess object and return true if the operation should be cancelled
+    * Fire the beforeUpdate event on an entityAccess object and return true if the operation should be cancelled
     * @param persistentEntity The entity
     * @param entityAccess The entity access
     * @return true if the operation should be cancelled
@@ -248,6 +239,19 @@ public abstract class EntityPersister implements Persister {
        return event.isCancelled();
    }
 
+    /**
+     * Fire the beforeDelete event on an entityAccess object and return true if the operation should be cancelled
+     * @param persistentEntity The entity
+     * @param entityAccess The entity access
+     * @return true if the operation should be cancelled
+     */
+    public boolean cancelDelete( final PersistentEntity persistentEntity,
+                                 final EntityAccess entityAccess) {
+        PreDeleteEvent event = new PreDeleteEvent(session.getDatastore(), persistentEntity, entityAccess);
+        publisher.publishEvent(event);
+        return event.isCancelled();
+    }
+
     public void firePostUpdateEvent(@SuppressWarnings("hiding") final PersistentEntity persistentEntity,
             final EntityAccess entityAccess) {
         publisher.publishEvent(new PostUpdateEvent(
@@ -257,6 +261,18 @@ public abstract class EntityPersister implements Persister {
     public void firePostDeleteEvent(@SuppressWarnings("hiding") final PersistentEntity persistentEntity,
             final EntityAccess entityAccess) {
         publisher.publishEvent(new PostDeleteEvent(
+                session.getDatastore(), persistentEntity, entityAccess));
+    }
+
+    public void firePreLoadEvent(@SuppressWarnings("hiding") final PersistentEntity persistentEntity,
+            final EntityAccess entityAccess) {
+        publisher.publishEvent(new PreLoadEvent(
+                session.getDatastore(), persistentEntity, entityAccess));
+    }
+
+    public void firePostLoadEvent(@SuppressWarnings("hiding") final PersistentEntity persistentEntity,
+            final EntityAccess entityAccess) {
+        publisher.publishEvent(new PostLoadEvent(
                 session.getDatastore(), persistentEntity, entityAccess));
     }
 

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -24,6 +24,8 @@ import javax.persistence.FlushModeType;
 import org.grails.datastore.mapping.cache.TPCacheAdapter;
 import org.grails.datastore.mapping.cache.TPCacheAdapterRepository;
 import org.grails.datastore.mapping.collection.*;
+import org.grails.datastore.mapping.engine.event.PostDeleteEvent;
+import org.grails.datastore.mapping.engine.event.PreLoadEvent;
 import org.grails.datastore.mapping.engine.internal.MappingUtils;
 import org.grails.datastore.mapping.engine.types.CustomTypeMarshaller;
 import org.grails.datastore.mapping.model.*;
@@ -217,16 +219,26 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
     @Override
     protected final void deleteEntities(PersistentEntity persistentEntity, Iterable objects) {
         if (objects != null) {
-            final List<K> keys = new ArrayList<K>();
+            final Set<K> keys = new LinkedHashSet<K>();
+            final List deleteList = new ArrayList();
             for (Object object : objects) {
                 K key = readIdentifierFromObject(object);
                 if (key != null) {
-                    keys.add(key);
+                    if (!keys.contains(key)) {
+                        if (!cancelDelete(persistentEntity, createEntityAccess(persistentEntity, object))) {
+                            // only delete if not cancelled
+                            keys.add(key);
+                            deleteList.add(object);
+                        }
+                    }
                 }
             }
 
             if (!keys.isEmpty()) {
-                deleteEntries(getEntityFamily(), keys);
+                deleteEntries(getEntityFamily(), new ArrayList<K>(keys));
+                for (Object object : deleteList) {
+                    firePostDeleteEvent(persistentEntity, createEntityAccess(persistentEntity, object));
+                }
             }
         }
     }
@@ -405,10 +417,16 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
 
                     if (embeddedEntry != null) {
                         Object embeddedInstance = newEntityInstance(embedded.getAssociatedEntity());
-                        createEntityAccess(embedded.getAssociatedEntity(), embeddedInstance);
                         refreshObjectStateFromNativeEntry(embedded.getAssociatedEntity(),
                               embeddedInstance, null, embeddedEntry, true);
                         ea.setProperty(propKey, embeddedInstance);
+                        if (embedded.isBidirectional()) {
+                            Association inverseSide = embedded.getInverseSide();
+                            // fix up the owner link
+                            EntityAccess embeddedEa =
+                                    createEntityAccess(embedded.getAssociatedEntity(), embeddedInstance);
+                            embeddedEa.setProperty(inverseSide.getName(), obj);
+                        }
                     }
                 }
 
@@ -563,6 +581,8 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
                 }
             }
         }
+        // entity is now fully loaded.
+        firePostLoadEvent(persistentEntity, ea);
     }
 
     /**

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/DomainEventsSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/DomainEventsSpec.groovy
@@ -1,6 +1,7 @@
 package grails.gorm.tests
 
 import org.grails.datastore.mapping.core.Session
+import grails.gorm.DetachedCriteria
 
 /**
  * @author graemerocher
@@ -75,6 +76,34 @@ class DomainEventsSpec extends GormDatastoreSpec {
         then:
             1 == PersonEvent.STORE.beforeDelete
             1 == PersonEvent.STORE.afterDelete
+    }
+
+    void "Test multi-delete events"() {
+        given:
+            def freds = (1..3).collect {
+                new PersonEvent(name: "Fred$it").save(flush:true)
+            }
+            session.clear()
+
+        when:
+            freds = PersonEvent.findAllByIdInList(freds*.id)
+
+        then:
+            3 == freds.size()
+            0 == PersonEvent.STORE.beforeDelete
+            0 == PersonEvent.STORE.afterDelete
+
+        when:
+            new DetachedCriteria(PersonEvent).build {
+                'in'('id', freds*.id)
+            }.deleteAll()
+            session.flush()
+            freds = PersonEvent.findAllByIdInList(freds*.id)
+
+        then:
+            0 == freds.size()
+            3 == PersonEvent.STORE.beforeDelete
+            3 == PersonEvent.STORE.afterDelete
     }
 
     void "Test before update event"() {
@@ -155,6 +184,25 @@ class DomainEventsSpec extends GormDatastoreSpec {
                 1 == PersonEvent.STORE.beforeLoad
             }
             1 == PersonEvent.STORE.afterLoad
+    }
+
+    void "Test multi-load events"() {
+        given:
+            def freds = (1..3).collect {
+                new PersonEvent(name: "Fred$it").save(flush:true)
+            }
+            session.clear()
+
+        when:
+            freds = PersonEvent.findAllByIdInList(freds*.id)
+
+        then:
+            3 == freds.size()
+            if (!'JpaSession'.equals(session.getClass().simpleName)) {
+                // JPA doesn't seem to support a pre-load event
+                3 == PersonEvent.STORE.beforeLoad
+            }
+            3 == PersonEvent.STORE.afterLoad
     }
 
     void "Test bean autowiring"() {


### PR DESCRIPTION
- Make sure events are used event when loading/deleting
  multiple objects for mongo and gemfire
- Added convenience methods to EntityPersister
- Refactored to use convenience methods where possible
- Removed some event firing from EntityPersister (to avoid double
  firing), so pushed it down into Gemfire and NativeEntry persisters.
- Added some extra test specs to cover the changes.
- Prevent delete events firing N times per entity when deleting N entities!
