### PR TITLE
GPMONGODB-226 Gracefully handle sub-types in embedded collections.

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -352,6 +352,13 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
         return obj;
     }
 
+    public Object createObjectFromEmbeddedNativeEntry(PersistentEntity persistentEntity, T nativeEntry) {
+        persistentEntity = discriminatePersistentEntity(persistentEntity, nativeEntry);
+        Object obj = newEntityInstance(persistentEntity);
+        refreshObjectStateFromNativeEntry(persistentEntity, obj, null, nativeEntry, true);
+        return obj;
+    }
+
     protected void cacheNativeEntry(PersistentEntity persistentEntity,
             Serializable nativeKey, T nativeEntry) {
         SessionImplementor<Object> si = (SessionImplementor<Object>) session;
@@ -416,9 +423,8 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
                     T embeddedEntry = getEmbedded(nativeEntry, propKey);
 
                     if (embeddedEntry != null) {
-                        Object embeddedInstance = newEntityInstance(embedded.getAssociatedEntity());
-                        refreshObjectStateFromNativeEntry(embedded.getAssociatedEntity(),
-                              embeddedInstance, null, embeddedEntry, true);
+                        Object embeddedInstance =
+                                createObjectFromEmbeddedNativeEntry(embedded.getAssociatedEntity(), embeddedEntry);
                         ea.setProperty(propKey, embeddedInstance);
                         if (embedded.isBidirectional()) {
                             Association inverseSide = embedded.getInverseSide();
@@ -429,7 +435,6 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
                         }
                     }
                 }
-
                 else {
                     ToOne association = (ToOne) prop;
 
@@ -454,6 +459,7 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
                     }
                     if (isEmbeddedEntry(tmp)) {
                         PersistentEntity associatedEntity = ((ToOne) prop).getAssociatedEntity();
+                        associatedEntity = discriminatePersistentEntity(associatedEntity, (T) tmp);
                         Object instance = newEntityInstance(associatedEntity);
                         refreshObjectStateFromNativeEntry(associatedEntity,instance, null, (T) tmp, false);
                         ea.setProperty(prop.getName(), instance);

--- a/grails-datastore-gorm-mongo/src/test/groovy/org/grails/datastore/gorm/mongo/EmbeddedAssociationSpec.groovy
+++ b/grails-datastore-gorm-mongo/src/test/groovy/org/grails/datastore/gorm/mongo/EmbeddedAssociationSpec.groovy
@@ -6,7 +6,7 @@ import grails.persistence.Entity
 class EmbeddedAssociationSpec extends GormDatastoreSpec {
 
     static {
-        GormDatastoreSpec.TEST_CLASSES << Individual << Individual2 << Address
+        GormDatastoreSpec.TEST_CLASSES << Individual << Individual2 << Address << LongAddress
     }
 
     void "Test persistence of embedded entities"() {
@@ -95,6 +95,95 @@ class EmbeddedAssociationSpec extends GormDatastoreSpec {
             results[0].name == 'Bob'
 
     }
+
+    void "Test persistence of embedded sub-class entities"() {
+        given:"A domain with an embedded association"
+            def i = new Individual(name:"Oliver", address: new LongAddress(postCode:"30483", firstLine: "1 High Street",
+                city: "Timbuktu"))
+
+            i.save(flush:true)
+            session.clear()
+
+        when:"When domain is queried"
+            i = Individual.findByName("Oliver")
+
+        then:"The embedded association is correctly loaded"
+            i != null
+            i.name == 'Oliver'
+            i.address instanceof LongAddress
+            i.address.postCode == '30483'
+            i.address.firstLine == '1 High Street'
+            i.address.city == 'Timbuktu'
+
+        when:"The embedded association is updated"
+            i.address.firstLine = "2 High Street"
+            i.save(flush:true)
+            session.clear()
+            i = Individual.get(i.id)
+
+        then:"The embedded association is correctly updated"
+            i != null
+            i.name == 'Oliver'
+            i.address instanceof LongAddress
+            i.address.firstLine == '2 High Street'
+
+
+        when:"An embedded association is queried"
+            session.clear()
+            i = Individual.createCriteria().get {
+                address {
+                    eq 'city', 'Timbuktu'
+                }
+            }
+
+        then:"The correct results are returned"
+            i != null
+            i.name == 'Oliver'
+            i.address instanceof LongAddress
+            i.address.city == 'Timbuktu'
+    }
+
+    void "Test persistence of embedded sub-class entity collection"() {
+        given:"An entity with an embedded entity collection"
+            def i = new Individual2(name:"Ed", address: new Address(postCode:"30483"))
+            i.otherAddresses = [new LongAddress(postCode: "12345", city: 'Auckland', firstLine: '1 Long Road'),
+                    new Address(postCode: "23456")]
+            i.save(flush:true)
+            session.clear()
+
+        when:"The entity is queried"
+            i = Individual2.findByName("Ed")
+
+        then:"The object was correctly persisted"
+            i != null
+            i.name == 'Ed'
+            i.address != null
+            i.address.postCode == '30483'
+            i.otherAddresses != null
+            i.otherAddresses.size() == 2
+            i.otherAddresses[0] instanceof LongAddress
+            i.otherAddresses[0].postCode == '12345'
+            i.otherAddresses[0].city == 'Auckland'
+            !(i.otherAddresses[1] instanceof LongAddress)
+            i.otherAddresses[1].postCode == '23456'
+
+        when:"The embedded collection association is queried"
+            def i2 = new Individual2(name:"Felix", address: new Address(postCode:"345334"))
+            i2.otherAddresses = [new LongAddress(postCode: "35432", city: "London", firstLine: "1 Oxford Road"),
+                    new Address(postCode: "34542")]
+            i2.save(flush:true)
+
+            session.clear()
+            def results = Individual2.createCriteria().list {
+                otherAddresses {
+                    eq 'city', 'Auckland'
+                }
+            }
+
+        then:"The correct results are returned"
+            results.size() == 1
+            results[0].name == 'Ed'
+    }
 }
 
 @Entity
@@ -126,4 +215,10 @@ class Individual2 {
 class Address {
     Long id
     String postCode
+}
+
+@Entity
+class LongAddress extends Address {
+    String firstLine
+    String city
 }


### PR DESCRIPTION
- Dropped unnecessary use of _embeddedClassName, using existing _class property instead
- Handle subtypes with one-to-one as well as one-to-many.
- Add test cases for the changes.
