### PR TITLE
MongoDB optimistic locking updates implemented.

### DIFF
--- a/grails-documentation-mongo/src/docs/guide/3.3 Customizing the WriteConcern.gdoc
+++ b/grails-documentation-mongo/src/docs/guide/3.3 Customizing the WriteConcern.gdoc
@@ -12,3 +12,7 @@ class Person {
     }
 }
 {code}
+
+{note}
+For versioned entities, if a lower level of WriteConcern than WriteConcern.ACKNOWLEDGE is specified, WriteConcern.ACKNOWLEDGE will also be used for updates, to ensure that optimistic locking failures are reported.
+{note}


### PR DESCRIPTION
Version is now atomically updated using a 'compare and exchange' type
atomic operation, avoiding possible race conditions in a
multi-threaded or multi-process situation.

Note that this means at least an 'acknowledge' level of write concern is always
used for versioned entities.

Added a corresponding note to the docs.

I also ran the test suite and had no failures.
