### PR TITLE
Make loaded set order deterministic by using LinkedHashSet.

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/internal/MappingUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/internal/MappingUtils.java
@@ -48,9 +48,9 @@ public class MappingUtils {
     }
 
     /**
-     * Creates a concrete collection for the suppied interface
+     * Creates a concrete collection for the supplied interface
      * @param interfaceType The interface
-     * @return ArrayList for List, TreeSet for SortedSet, HashSet for Set etc.
+     * @return ArrayList for List, TreeSet for SortedSet, LinkedHashSet for Set etc.
      */
     @SuppressWarnings("rawtypes")
     public static Collection createConcreteCollection(Class interfaceType) {
@@ -65,7 +65,7 @@ public class MappingUtils {
             elements = new ArrayDeque();
         }
         else {
-            elements = new HashSet();
+            elements = new LinkedHashSet();
         }
         return elements;
     }


### PR DESCRIPTION
This can make it easier to write test cases, since set elements will
come in the same order as in the persisted set.

It is also consistent with Groovy, which considers LinkedHashSet the default Set type
(e.g. [] as Set returns a LinkedHashSet in recent Groovy versions).
