### PR TITLE
MongoDB optimistic locking updates implemented.

### DIFF
--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
@@ -15,9 +15,6 @@
 package org.grails.datastore.mapping.mongo.engine;
 
 import java.io.Serializable;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.URL;
 import java.util.*;
 
 import com.mongodb.*;
@@ -110,7 +107,42 @@ public class MongoEntityPersister extends NativeEntryEntityPersister<DBObject, O
     protected void setEmbeddedCollection(final DBObject nativeEntry, final String key, Collection<?> instances,
             List<DBObject> embeddedEntries) {
         if (instances == null || instances.isEmpty()) {
-            nativeEntry.put(key, null);
+            SessionImplementor impl = (SessionImplementor) getSession();
+            final Object oid = nativeEntry.get(MONGO_ID_FIELD);
+            final DBObject ni = nativeEntry;
+            nativeEntry.removeField(key);
+            Object inSession = impl.getCachedInstance(getPersistentEntity().getJavaClass(), (Serializable) oid);
+            if(inSession != null) {
+
+                impl.addPendingUpdate(new PendingUpdateAdapter(getPersistentEntity(), oid, nativeEntry, null) {
+                    @Override
+                    public void run() {
+                        mongoTemplate.execute(new DbCallback<Object>() {
+                            public Object doInDB(DB con) throws MongoException, DataAccessException {
+                                @SuppressWarnings("hiding") String collectionName = getCollectionName(getPersistentEntity(), ni);
+                                DBCollection dbCollection = con.getCollection(collectionName);
+
+                                DBObject updateOp = new BasicDBObject();
+
+                                updateOp.put("$unset", new BasicDBObject(key, ""));
+
+                                DBObject dbo = createDBObjectWithKey(oid);
+
+                                MongoSession mongoSession = (MongoSession) session;
+                                WriteConcern writeConcern = mongoSession.getDeclaredWriteConcern(getPersistentEntity());
+                                if(writeConcern != null)
+                                    dbCollection.update(dbo, updateOp, false, false, writeConcern);
+                                else
+                                    dbCollection.update(dbo, updateOp, false, false);
+                                return null;
+                            }
+                        });
+
+
+                    }
+                });
+            }
+
             return;
         }
 
@@ -597,20 +629,36 @@ public class MongoEntityPersister extends NativeEntryEntityPersister<DBObject, O
                 DBCollection dbCollection = con.getCollection(collectionName);
                 DBObject dbo = createDBObjectWithKey(key);
 
-                if (isVersioned(ea)) {
-                    // TODO this should be done with a CAS approach if possible
-                    DBObject previous = dbCollection.findOne(dbo);
-                    checkVersion(ea, previous, persistentEntity, key);
+                boolean versioned = isVersioned(ea);
+                if (versioned) {
+                    Object currentVersion = getCurrentVersion(ea);
+                    incrementVersion(ea);
+                    // query for old version to ensure atomicity
+                    if (currentVersion != null) {
+                        dbo.put("version", currentVersion);
+                    }
                 }
 
                 DBObject newEntry = modifyNullsToUnsets(entry);
 
                 MongoSession mongoSession = (MongoSession) session;
                 WriteConcern writeConcern = mongoSession.getDeclaredWriteConcern(getPersistentEntity());
+                WriteResult result;
                 if(writeConcern != null)
-                    dbCollection.update(dbo, newEntry, false, false, writeConcern);
+                    result = dbCollection.update(dbo, newEntry, false, false, writeConcern);
                 else
-                    dbCollection.update(dbo, newEntry, false, false);
+                    result = dbCollection.update(dbo, newEntry, false, false);
+                if (versioned) {
+                    // ok, we need to check whether the write worked:
+                    // note that this will use the standard write concern unless it wasn't at least ACKNOWLEDGE:
+                    CommandResult error = result.getLastError(WriteConcern.ACKNOWLEDGED);
+                    // may as well handle any networking errors:
+                    error.throwOnError();
+                    // if the document count "n" of the update was 0, the versioning check must have failed:
+                    if (error.getInt("n") == 0) {
+                        throw new OptimisticLockingException(persistentEntity, key);
+                    }
+                }
                 return null;
             }
         });
@@ -647,18 +695,12 @@ public class MongoEntityPersister extends NativeEntryEntityPersister<DBObject, O
         return (Collection)nativeEntry.get(manyToMany.getName() + "_$$manyToManyIds");
     }
 
-    protected void checkVersion(final EntityAccess ea, final DBObject previous,
-                                final PersistentEntity persistentEntity, final Object key) {
-        Object oldVersion = previous != null ? previous.get("version") : null;
+    protected Object getCurrentVersion(final EntityAccess ea) {
         Object currentVersion = ea.getProperty("version");
         if (Number.class.isAssignableFrom(ea.getPropertyType("version"))) {
-            oldVersion = oldVersion != null ? ((Number)oldVersion).longValue() : oldVersion;
             currentVersion = currentVersion != null ? ((Number)currentVersion).longValue() : currentVersion;
         }
-        if (oldVersion != null && currentVersion != null && !oldVersion.equals(currentVersion)) {
-            throw new OptimisticLockingException(persistentEntity, key);
-        }
-        incrementVersion(ea);
+        return currentVersion;
     }
 
     @Override

--- a/grails-documentation-mongo/src/docs/guide/3.3 Customizing the WriteConcern.gdoc
+++ b/grails-documentation-mongo/src/docs/guide/3.3 Customizing the WriteConcern.gdoc
@@ -12,3 +12,7 @@ class Person {
     }
 }
 {code}
+
+{note}
+For versioned entities, if a lower level of WriteConcern than WriteConcern.ACKNOWLEDGE is specified, WriteConcern.ACKNOWLEDGE will also be used for updates, to ensure that optimistic locking failures are reported.
+{note}


### PR DESCRIPTION
Version is now atomically updated using a 'compare and exchange' type
atomic operation, avoiding possible race conditions in a
multi-threaded or multi-process situation.

Note that this means at least an 'acknowledge' level of write concern is always
used for versioned entities.

Added a corresponding note to the docs.

REBASED onto master to resolve merge conflict! Merge either this or #87, not both!
