### PR TITLE
Make AbstractSession.getCachedInstance meet contract of method.

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractSession.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractSession.java
@@ -420,7 +420,7 @@ public abstract class AbstractSession<N> extends AbstractAttributeStoringSession
 
     public Object getCachedInstance(Class type, Serializable key) {
         if (type == null || key == null) {
-            return false;
+            return null;
         }
 
         return getInstanceCache(type).get(key);


### PR DESCRIPTION
- Method should not return false but null.
- Various callers using method check whether return value != null and currently get
  false positives (since Boolean.FALSE != null).
