### PR TITLE
Add bidirectional association support for embedded entities.

### DIFF
--- a/grails-datastore-gorm-mongo/src/test/groovy/org/grails/datastore/gorm/mongo/EmbeddedAssociationSpec.groovy
+++ b/grails-datastore-gorm-mongo/src/test/groovy/org/grails/datastore/gorm/mongo/EmbeddedAssociationSpec.groovy
@@ -5,8 +5,9 @@ import grails.persistence.Entity
 
 class EmbeddedAssociationSpec extends GormDatastoreSpec {
 
-    static {
-        GormDatastoreSpec.TEST_CLASSES << Individual << Individual2 << Address << LongAddress
+    @Override
+    List getDomainClasses() {
+        return [Individual, Individual2, Address, LongAddress]
     }
 
     void "Test persistence of embedded entities"() {
@@ -62,6 +63,37 @@ class EmbeddedAssociationSpec extends GormDatastoreSpec {
 
     }
 
+    void "Test persistence of embedded entities with links to parent"() {
+        given:"A domain with an embedded association"
+            def i = new Individual(name:"Bob", address: new Address(postCode:"30483"))
+            i.address.individual = i
+            i.save(flush:true)
+            session.clear()
+
+        when:"When domain is queried"
+            i = Individual.findByName("Bob")
+
+        then:"The embedded association is correctly loaded"
+            i != null
+            i.name == 'Bob'
+            i.address != null
+            i.address.postCode == '30483'
+            i.address.individual == i
+
+        when:"The embedded association is updated"
+            i.address = new Address(postCode: '28749')
+            i.save(flush:true)
+            session.clear()
+            i = Individual.get(i.id)
+
+        then:"The embedded association is correctly updated"
+            i != null
+            i.name == 'Bob'
+            i.address != null
+            i.address.postCode == '28749'
+            i.address.individual == i
+    }
+
     void "Test persistence of embedded entity collections"() {
         given:"An entity with an embedded entity collection"
             def i = new Individual2(name:"Bob", address: new Address(postCode:"30483"))
@@ -98,6 +130,44 @@ class EmbeddedAssociationSpec extends GormDatastoreSpec {
             results.size() == 1
             results[0].name == 'Bob'
 
+    }
+
+    void "Test persistence of embedded collections with links to parent"() {
+        given:"A domain with an embedded association"
+        def i = new Individual2(name:"Bob", address: new Address(postCode:"30483"))
+
+        when:"A collection is added via addTo"
+        [new Address(postCode: "12345"), new Address(postCode: "23456")].each { i.addToOtherAddresses(it) }
+
+        then:"Back-links are populated"
+        i.otherAddresses[0].individual2 == i
+        i.otherAddresses[1].individual2 == i
+
+        when:"Entity is saved and session is cleared"
+        i.save(flush:true)
+        session.clear()
+        i = Individual2.findByName("Bob")
+
+        then:"The object was correctly persisted"
+        i != null
+        i.name == 'Bob'
+        i.otherAddresses != null
+        i.otherAddresses.size() == 2
+        i.otherAddresses[0].individual2 == i
+        i.otherAddresses[1].individual2 == i
+
+        when:"The embedded association is updated"
+        i.otherAddresses = [new Address(postCode: '28749')]
+        i.save(flush:true)
+        session.clear()
+        i = Individual2.get(i.id)
+
+        then:"The embedded association is correctly updated"
+        i != null
+        i.name == 'Bob'
+        i.otherAddresses != null
+        i.otherAddresses.size() == 1
+        i.otherAddresses[0].individual2 == i
     }
 
     void "Test persistence of embedded sub-class entities"() {
@@ -218,6 +288,15 @@ class Individual2 {
 class Address {
     Long id
     String postCode
+    Individual individual
+    Individual2 individual2
+
+    static belongsTo = [Individual, Individual2]
+
+    static constraints = {
+        individual nullable: true
+        individual2 nullable: true
+    }
 }
 
 @Entity


### PR DESCRIPTION
- Modify test cases to check inverse links work for one-to-many and one-to-one.
- Modify mapping strategy class to use same bidirectional code for embedded and non-embedded.
- Prevent infinite recursion saving embedded entities with bidirectional associations.
- Implement code to fix-up back-links when loading embedded entities.

Test suite passes for MongoDB and nothing else seems to have been broken.
I will run the contributor agreement past my employers and hopefully get it back to you soon.
