### PR TITLE
update of dependency concurrentlinkedhashmap_lru

### DIFF
--- a/grails-datastore-core/build.gradle
+++ b/grails-datastore-core/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.2_jdk5"
+    compile "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.3.1"
     compile "org.springframework:spring-core:$springVersion" , {
         exclude module:'commons-logging'
     }


### PR DESCRIPTION
as discussed some time ago on grails-dev I've updated the dependency of concurrentlinkedhashmap_lru to 1.3.1.

Since this change must be in sync with the same update for grails-core, please apply the both pull-requests at the same time. Also, any new build of grails-core needs to have a updated 1.1.4-SNAPSHOT of grails-datastore-core deployed to repo.grails.org.

The core issue is that concurrentlinkedhashmap_lru 1.2_jdk5 and 1.3.1 are not backwards compatible.
