### PR TITLE
Proposed fix for GRAILS-9902

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -1648,7 +1648,9 @@ public abstract class NativeEntryEntityPersister<T, K> extends LockableEntityPer
             }
             else if (prop instanceof Custom) {
                 CustomTypeMarshaller marshaller = ((Custom)prop).getCustomTypeMarshaller();
-                return !areEqual(marshaller.read(prop, entry), currentValue, key);
+                if (!areEqual(marshaller.read(prop, entry), currentValue, key)) {
+                    return true;
+                }
             }
             else {
                 throw new UnsupportedOperationException("dirty not detected for property " + prop.toString() + " " + prop.getClass().getSuperclass().toString());


### PR DESCRIPTION
This pull request includes a proposed fix for GRAILS-9902: NativeEntryEntityPersister#isDirty skips unchecked properties once it encounters a Custom property
