### PR TITLE
Fix tests that failed after switching HibernateGormStaticApi to use @CompileStatic

### DIFF
--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/GormDatastoreSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/GormDatastoreSpec.groovy
@@ -38,7 +38,7 @@ abstract class GormDatastoreSpec extends Specification {
 
     def setup() {
         cleanRegistry()
-        session = setupClass.setup(TEST_CLASSES + getDomainClasses())
+        session = setupClass.setup(((TEST_CLASSES + getDomainClasses()) as Set) as List)
         DatastoreUtils.bindSession session
     }
 


### PR DESCRIPTION
Fix tests that failed after switching HibernateGormStaticApi to use @CompileStatic. I noticed a few @CS bugs that needed some workarounds.
