### PR TITLE
hibernate3 module changes synchronized to hibernate4 module

### DIFF
--- a/grails-datastore-gorm-hibernate4/merging_changes.txt
+++ b/grails-datastore-gorm-hibernate4/merging_changes.txt
@@ -1,0 +1,9 @@
+
+Hibernate3 and Hibernate4 modules should be kept up-to-date manually.
+Code has been copy&pasted.
+
+Here is an example of patching hibernate4 with changes from hibernate3 module:
+git diff 114b02...master ../grails-datastore-gorm-hibernate | sed -e 's/hibernate3/hibernate4/g' | patch -p2 -f
+
+114b02 is the last merge point in this example
+

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateTransactionManager.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateTransactionManager.groovy
@@ -15,9 +15,11 @@
  */
 package org.codehaus.groovy.grails.orm.hibernate
 
+import groovy.transform.CompileStatic
+
 import org.hibernate.FlushMode
-import org.hibernate.Session
 import org.springframework.orm.hibernate4.HibernateTransactionManager
+import org.springframework.orm.hibernate4.HibernateTransactionManager.HibernateTransactionObject
 import org.springframework.transaction.TransactionDefinition
 
 /**
@@ -32,8 +34,13 @@ class GrailsHibernateTransactionManager extends HibernateTransactionManager {
         super.doBegin transaction, definition
 
         if (definition.isReadOnly()) {
-            // always set to manual; the base class doesn't because the OSIVI has already registered a session
-            transaction.sessionHolder.session.flushMode = FlushMode.MANUAL
+            // transaction is HibernateTransactionManager.HibernateTransactionObject private class instance
+            transaction.sessionHolder?.session?.with {
+                // always set to manual; the base class doesn't because the OSIVI has already registered a session
+                flushMode = FlushMode.MANUAL
+                // set session to load entities in read-only mode
+                defaultReadOnly = true
+            }
         }
     }
 }

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormEnhancer.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormEnhancer.groovy
@@ -15,6 +15,10 @@
  */
 package org.codehaus.groovy.grails.orm.hibernate
 
+import groovy.transform.CompileStatic;
+
+import groovy.transform.CompileStatic;
+
 import org.codehaus.groovy.grails.commons.DomainClassArtefactHandler
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.orm.hibernate.cfg.HibernateNamedQueriesBuilder
@@ -42,6 +46,7 @@ import org.springframework.transaction.PlatformTransactionManager
  * @author Graeme Rocher
  * @since 1.0
  */
+@CompileStatic
 class HibernateGormEnhancer extends GormEnhancer {
 
     private ClassLoader classLoader
@@ -60,33 +65,31 @@ class HibernateGormEnhancer extends GormEnhancer {
     }
 
     static List createPersistentMethods(GrailsApplication grailsApplication, ClassLoader classLoader, Datastore datastore) {
-        def sessionFactory = datastore.sessionFactory
+        HibernateDatastore hibernateDatastore = (HibernateDatastore)datastore
+        def sessionFactory = hibernateDatastore.sessionFactory
         Collections.unmodifiableList([
-            new FindAllByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new FindAllByBooleanPropertyPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new FindOrCreateByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new FindOrSaveByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new FindByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new FindByBooleanPropertyPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new CountByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader),
-            new ListOrderByPersistentMethod(datastore, grailsApplication, sessionFactory, classLoader) ])
+            new FindAllByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new FindAllByBooleanPropertyPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new FindOrCreateByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new FindOrSaveByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new FindByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new FindByBooleanPropertyPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new CountByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader),
+            new ListOrderByPersistentMethod(hibernateDatastore, grailsApplication, sessionFactory, classLoader) ])
     }
 
-    @SuppressWarnings("unchecked")
-    protected GormValidationApi getValidationApi(Class cls) {
-        new HibernateGormValidationApi(cls, datastore, classLoader)
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    protected GormStaticApi getStaticApi(Class cls) {
-        new HibernateGormStaticApi(cls, datastore, finders, classLoader, transactionManager)
+    protected <D> GormValidationApi<D> getValidationApi(Class<D> cls) {
+        new HibernateGormValidationApi<D>(cls, (HibernateDatastore)datastore, classLoader)
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected GormInstanceApi getInstanceApi(Class cls) {
-        new HibernateGormInstanceApi(cls, datastore, classLoader)
+    protected <D> GormStaticApi<D> getStaticApi(Class<D> cls) {
+        new HibernateGormStaticApi<D>(cls, (HibernateDatastore)datastore, finders, classLoader, transactionManager)
+    }
+
+    @Override
+    protected <D> GormInstanceApi<D> getInstanceApi(Class<D> cls) {
+        new HibernateGormInstanceApi<D>(cls, (HibernateDatastore)datastore, classLoader)
     }
 
     @Override

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormValidationApi.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormValidationApi.groovy
@@ -15,17 +15,20 @@
  */
 package org.codehaus.groovy.grails.orm.hibernate
 
+import groovy.transform.CompileStatic;
+
 import org.codehaus.groovy.grails.domain.GrailsDomainClassMappingContext
 import org.codehaus.groovy.grails.orm.hibernate.metaclass.ValidatePersistentMethod
 import org.grails.datastore.gorm.GormValidationApi
 
-class HibernateGormValidationApi extends GormValidationApi {
+@CompileStatic
+class HibernateGormValidationApi<D> extends GormValidationApi<D> {
 
     private ClassLoader classLoader
 
     ValidatePersistentMethod validateMethod
 
-    HibernateGormValidationApi(Class persistentClass, HibernateDatastore datastore, ClassLoader classLoader) {
+    HibernateGormValidationApi(Class<D> persistentClass, HibernateDatastore datastore, ClassLoader classLoader) {
         super(persistentClass, datastore)
 
         this.classLoader = classLoader
@@ -34,7 +37,7 @@ class HibernateGormValidationApi extends GormValidationApi {
 
         def mappingContext = datastore.mappingContext
         if (mappingContext instanceof GrailsDomainClassMappingContext) {
-            GrailsDomainClassMappingContext domainClassMappingContext = mappingContext
+            GrailsDomainClassMappingContext domainClassMappingContext = (GrailsDomainClassMappingContext)mappingContext
             def grailsApplication = domainClassMappingContext.getGrailsApplication()
             def validator = mappingContext.getEntityValidator(
                     mappingContext.getPersistentEntity(persistentClass.name))
@@ -44,7 +47,7 @@ class HibernateGormValidationApi extends GormValidationApi {
     }
 
     @Override
-    boolean validate(instance) {
+    boolean validate(D instance) {
         if (validateMethod) {
             return validateMethod.invoke(instance, "validate", [] as Object[])
         }
@@ -52,7 +55,7 @@ class HibernateGormValidationApi extends GormValidationApi {
     }
 
     @Override
-    boolean validate(instance, boolean evict) {
+    boolean validate(D instance, boolean evict) {
         if (validateMethod) {
             return validateMethod.invoke(instance, "validate", [evict] as Object[])
         }
@@ -60,7 +63,7 @@ class HibernateGormValidationApi extends GormValidationApi {
     }
 
     @Override
-    boolean validate(instance, Map arguments) {
+    boolean validate(D instance, Map arguments) {
         if (validateMethod) {
             return validateMethod.invoke(instance, "validate", [arguments] as Object[])
         }
@@ -68,10 +71,10 @@ class HibernateGormValidationApi extends GormValidationApi {
     }
 
     @Override
-    boolean validate(instance, List fields) {
+    boolean validate(D instance, List fields) {
         if (validateMethod) {
             return validateMethod.invoke(instance, "validate", [fields] as Object[])
         }
-        return super.validate(instance, arguments)
+        return super.validate(instance, fields)
     }
 }

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
@@ -39,6 +39,7 @@ import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty;
 import org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateDomainClass;
 import org.codehaus.groovy.grails.orm.hibernate.proxy.GroovyAwareJavassistProxyFactory;
 import org.codehaus.groovy.grails.orm.hibernate.proxy.HibernateProxyHandler;
+import org.codehaus.groovy.grails.web.context.GrailsConfigUtils;
 import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.FlushMode;
@@ -88,6 +89,7 @@ public class GrailsHibernateUtil {
     public static final String ARGUMENT_CACHE = "cache";
     public static final String ARGUMENT_LOCK = "lock";
     public static final String CONFIG_PROPERTY_CACHE_QUERIES="grails.hibernate.cache.queries";
+    public static final String CONFIG_PROPERTY_OSIV_READONLY="grails.hibernate.osiv.readonly";
     public static final Class<?>[] EMPTY_CLASS_ARRAY=new Class<?>[0];
 
     private static HibernateProxyHandler proxyHandler = new HibernateProxyHandler();
@@ -450,8 +452,11 @@ public class GrailsHibernateUtil {
     }
 
     public static boolean isCacheQueriesByDefault(GrailsApplication grailsApplication) {
-        Object o = grailsApplication.getFlatConfig().get(CONFIG_PROPERTY_CACHE_QUERIES);
-        return o != null && o instanceof Boolean ? (Boolean)o : false;
+        return GrailsConfigUtils.isConfigTrue(grailsApplication, CONFIG_PROPERTY_CACHE_QUERIES);
+    }
+    
+    public static boolean isOsivReadonly(GrailsApplication grailsApplication) {
+        return GrailsConfigUtils.isConfigTrue(grailsApplication, CONFIG_PROPERTY_OSIV_READONLY);
     }
 
     public static GroovyAwareJavassistProxyFactory buildProxyFactory(PersistentClass persistentClass) {

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/HibernateUtils.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/HibernateUtils.groovy
@@ -17,11 +17,11 @@ package org.codehaus.groovy.grails.orm.hibernate.cfg
 
 import grails.artefact.Enhanced
 import grails.util.GrailsNameUtils
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 
-import org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateTemplate
-import org.apache.commons.beanutils.PropertyUtils
+import org.codehaus.groovy.grails.commons.DomainClassArtefactHandler
 import org.codehaus.groovy.grails.commons.GrailsApplication
-import org.codehaus.groovy.grails.commons.GrailsClassUtils
 import org.codehaus.groovy.grails.commons.GrailsDomainClass
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty
 import org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateTemplate
@@ -30,14 +30,16 @@ import org.codehaus.groovy.grails.orm.hibernate.HibernateGormEnhancer
 import org.codehaus.groovy.grails.orm.hibernate.HibernateGormInstanceApi
 import org.codehaus.groovy.grails.orm.hibernate.HibernateGormStaticApi
 import org.codehaus.groovy.grails.orm.hibernate.HibernateGormValidationApi
+import org.codehaus.groovy.grails.orm.hibernate.support.ClosureEventTriggeringInterceptor
 import org.codehaus.groovy.grails.plugins.DomainClassGrailsPlugin
+import org.codehaus.groovy.runtime.InvokerHelper
+import org.codehaus.groovy.runtime.StringGroovyMethods
 import org.grails.datastore.mapping.core.Datastore
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
-import org.hibernate.FlushMode;
+import org.hibernate.FlushMode
 import org.hibernate.Session
 import org.hibernate.SessionFactory
-import org.hibernate.TypeMismatchException
 import org.hibernate.proxy.HibernateProxy
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -46,45 +48,30 @@ import org.springframework.context.ApplicationContext
 import org.springframework.dao.DataAccessException
 import org.springframework.transaction.PlatformTransactionManager
 
+@CompileStatic
 class HibernateUtils {
 
-    static final Logger LOG = LoggerFactory.getLogger(this)
-
-    static final LAZY_PROPERTY_HANDLER = { String propertyName ->
-        def propertyValue = PropertyUtils.getProperty(delegate, propertyName)
-        if (propertyValue instanceof HibernateProxy) {
-            propertyValue = GrailsHibernateUtil.unwrapProxy(propertyValue)
-        }
-        return propertyValue
-    }
+    static final Logger LOG = LoggerFactory.getLogger(HibernateUtils)
 
     /**
      * Overrides a getter on a property that is a Hibernate proxy in order to make sure the initialized object is returned hence avoiding Hibernate proxy hell.
      */
     static void handleLazyProxy(GrailsDomainClass domainClass, GrailsDomainClassProperty property) {
-        String propertyName = property.name
-        String getterName = GrailsClassUtils.getGetterName(propertyName)
-        String setterName = GrailsClassUtils.getSetterName(propertyName)
-        domainClass.metaClass."${getterName}" = LAZY_PROPERTY_HANDLER.clone().curry(propertyName)
-        domainClass.metaClass."${setterName}" = { PropertyUtils.setProperty(delegate, propertyName, it) }
-
-        for (GrailsDomainClass sub in domainClass.subClasses) {
-            handleLazyProxy(sub, sub.getPropertyByName(property.name))
-        }
+        // return lazy proxies
     }
 
-    static void enhanceSessionFactories(ApplicationContext ctx, GrailsApplication grailsApplication, source = null) {
+    static void enhanceSessionFactories(ApplicationContext ctx, GrailsApplication grailsApplication, Object source = null) {
 
         Map<SessionFactory, HibernateDatastore> datastores = [:]
 
-        for (entry in ctx.getBeansOfType(SessionFactory)) {
+        for (entry in ctx.getBeansOfType(SessionFactory).entrySet()) {
             SessionFactory sessionFactory = entry.value
             String beanName = entry.key
             String suffix = beanName - 'sessionFactory'
             enhanceSessionFactory sessionFactory, grailsApplication, ctx, suffix, datastores, source
         }
 
-        ctx.eventTriggeringInterceptor.datastores = datastores
+        ctx.getBean("eventTriggeringInterceptor", ClosureEventTriggeringInterceptor).datastores = datastores
     }
 
     static enhanceSessionFactory(SessionFactory sessionFactory, GrailsApplication application, ApplicationContext ctx) {
@@ -92,18 +79,18 @@ class HibernateUtils {
     }
 
     static enhanceSessionFactory(SessionFactory sessionFactory, GrailsApplication application,
-            ApplicationContext ctx, String suffix, Map<SessionFactory, HibernateDatastore> datastores, source = null) {
+            ApplicationContext ctx, String suffix, Map<SessionFactory, HibernateDatastore> datastores, Object source = null) {
 
         MappingContext mappingContext = ctx.getBean("grailsDomainClassMappingContext", MappingContext)
         PlatformTransactionManager transactionManager = ctx.getBean("transactionManager$suffix", PlatformTransactionManager)
-        final datastore = ctx.getBean("hibernateDatastore$suffix", Datastore)
+        HibernateDatastore datastore = (HibernateDatastore)ctx.getBean("hibernateDatastore$suffix", Datastore)
         datastores[sessionFactory] = datastore
         String datasourceName = suffix ? suffix[1..-1] : GrailsDomainClassProperty.DEFAULT_DATA_SOURCE
 
         HibernateGormEnhancer enhancer = new HibernateGormEnhancer(datastore, transactionManager, application)
 
         def enhanceEntity = { PersistentEntity entity ->
-            GrailsDomainClass dc = application.getDomainClass(entity.javaClass.name)
+            GrailsDomainClass dc = (GrailsDomainClass)application.getArtefact(DomainClassArtefactHandler.TYPE, entity.javaClass.name)
             if (!GrailsHibernateUtil.isMappedWithHibernate(dc) || !GrailsHibernateUtil.usesDatasource(dc, datasourceName)) {
                 return
             }
@@ -122,14 +109,14 @@ class HibernateUtils {
                     enhancer.enhance entity, true
                 }
 
-                DomainClassGrailsPlugin.addRelationshipManagementMethods(application.getDomainClass(entity.javaClass.name), ctx)
+                DomainClassGrailsPlugin.addRelationshipManagementMethods(dc, ctx)
             }
         }
 
         // If we are reloading via an onChange event, the source indicates the specific
         // entity that needs to be reloaded. Otherwise, just reload all of them.
         if (source) {
-            PersistentEntity entity = mappingContext.getPersistentEntity(source.name)
+            PersistentEntity entity = getPersistentEntity(mappingContext, InvokerHelper.getPropertySafe(source, 'name')?.toString())
             if (entity) {
                 enhanceEntity(entity)
             }
@@ -140,10 +127,16 @@ class HibernateUtils {
             }
         }
     }
+    
+    // workaround CS bug
+    @CompileStatic(TypeCheckingMode.SKIP)
+    private static PersistentEntity getPersistentEntity(mappingContext, String name) {
+        mappingContext.getPersistentEntity(name)
+    }
 
     static Map filterQueryArgumentMap(Map query) {
         def queryArgs = [:]
-        for (entry in query) {
+        for (entry in query.entrySet()) {
             if (entry.value instanceof CharSequence) {
                 queryArgs[entry.key] = entry.value.toString()
             }
@@ -166,66 +159,90 @@ class HibernateUtils {
         nullNames
     }
 
+    // http://jira.codehaus.org/browse/GROOVY-6138 prevents using CompileStatic for this method
+    @CompileStatic(TypeCheckingMode.SKIP)
     static void enhanceProxyClass(Class proxyClass) {
-        def mc = proxyClass.metaClass
-        if (mc.pickMethod('grailsEnhanced', GrailsHibernateUtil.EMPTY_CLASS_ARRAY)) {
+        MetaMethod grailsEnhancedMetaMethod = proxyClass.metaClass.getStaticMetaMethod("grailsEnhanced", null)
+        if (grailsEnhancedMetaMethod != null && grailsEnhancedMetaMethod.invoke(proxyClass, null) == proxyClass) {
             return
         }
-
+        
+        GroovyObject mc = (GroovyObject)InvokerHelper.getMetaClass(proxyClass)
+        MetaClass superMc = InvokerHelper.getMetaClass(proxyClass.getSuperclass())
+        
         // hasProperty
-        def originalHasProperty = mc.getMetaMethod("hasProperty", String)
-        mc.hasProperty = { String name ->
-            if (delegate instanceof HibernateProxy) {
-                return GrailsHibernateUtil.unwrapProxy(delegate).hasProperty(name)
+        registerMetaMethod(mc, 'hasProperty', { String name ->
+            Object obj = getDelegate()
+            boolean result = superMc.hasProperty(obj, name)
+            if (!result) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                result = unwrapped.getMetaClass().hasProperty(obj, name)
             }
-            return originalHasProperty.invoke(delegate, name)
-        }
+            return result
+        })
         // respondsTo
-        def originalRespondsTo = mc.getMetaMethod("respondsTo", String)
-        mc.respondsTo = { String name ->
-            if (delegate instanceof HibernateProxy) {
-                return GrailsHibernateUtil.unwrapProxy(delegate).respondsTo(name)
+        registerMetaMethod(mc, 'respondsTo', { String name ->
+            Object obj = getDelegate()
+            def result = superMc.respondsTo(obj, name)
+            if (!result) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                result = unwrapped.getMetaClass().respondsTo(obj, name)
             }
-            return originalRespondsTo.invoke(delegate, name)
-        }
-        def originalRespondsToTwoArgs = mc.getMetaMethod("respondsTo", String, Object[])
-        mc.respondsTo = { String name, Object[] args ->
-            if (delegate instanceof HibernateProxy) {
-                return GrailsHibernateUtil.unwrapProxy(delegate).respondsTo(name, args)
+            result
+        })
+        registerMetaMethod(mc, 'respondsTo', { String name, Object[] args ->
+            Object obj = getDelegate()
+            def result = superMc.respondsTo(obj, name, args)
+            if (!result) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                result = unwrapped.getMetaClass().respondsTo(obj, name, args)
             }
-            return originalRespondsToTwoArgs.invoke(delegate, name, args)
-        }
-        // getter
-        mc.propertyMissing = { String name ->
-            if (delegate instanceof HibernateProxy) {
-                return GrailsHibernateUtil.unwrapProxy(delegate)."$name"
-            }
-            throw new MissingPropertyException(name, delegate.getClass())
-        }
+            result
+        })
 
         // setter
-        mc.propertyMissing = { String name, val ->
-            if (delegate instanceof HibernateProxy) {
-                GrailsHibernateUtil.unwrapProxy(delegate)."$name" = val
+        registerMetaMethod(mc, 'propertyMissing', { String name, Object val ->
+            Object obj = getDelegate()
+            try {
+                superMc.setProperty(proxyClass, obj, name, val, true, true)
+            } catch (MissingPropertyException e) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                unwrapped.getMetaClass().setProperty(unwrapped, name, val)
             }
-            else {
-                throw new MissingPropertyException(name, delegate.getClass())
-            }
-        }
+        })
 
-        mc.methodMissing = { String name, args ->
-            if (delegate instanceof HibernateProxy) {
-                def obj = GrailsHibernateUtil.unwrapProxy(delegate)
-                return obj."$name"(*args)
+        // getter
+        registerMetaMethod(mc, 'propertyMissing', { String name ->
+            Object obj = getDelegate()
+            try {
+                return superMc.getProperty(proxyClass, obj, name, true, true)
+            } catch (MissingPropertyException e) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                unwrapped.getMetaClass().getProperty(unwrapped, name)
             }
-            throw new MissingPropertyException(name, delegate.getClass())
-        }
+        })
 
-        mc.grailsEnhanced = { true }
+        registerMetaMethod(mc, 'methodMissing', { String name, Object args ->
+            Object obj = getDelegate()
+            Object[] argsArray = (Object[])args
+            try {
+                superMc.invokeMethod(proxyClass, obj, name, argsArray, true, true)
+            } catch (MissingMethodException e) {
+                Object unwrapped = GrailsHibernateUtil.unwrapProxy((HibernateProxy)obj)
+                unwrapped.getMetaClass().invokeMethod(unwrapped, name, argsArray)
+            }
+        })
+        
+        ((GroovyObject)mc.getProperty('static')).setProperty("grailsEnhanced", { -> proxyClass })
     }
+    
+    private static final registerMetaMethod(MetaClass mc, String name, Closure c) {
+        ((GroovyObject)mc).setProperty(name, c)
+    }
+    
 
     static void enhanceProxy(HibernateProxy proxy) {
-        proxy.metaClass = GroovySystem.metaClassRegistry.getMetaClass(proxy.getClass())
+        // no need to do anything here
     }
 
     private static void registerNamespaceMethods(GrailsDomainClass dc, HibernateDatastore datastore,
@@ -233,7 +250,7 @@ class HibernateUtils {
             GrailsApplication application) {
 
         String getter = GrailsNameUtils.getGetterName(datasourceName)
-        if (dc.metaClass.methods.any { it.name == getter && it.parameterTypes.size() == 0 }) {
+        if (dc.metaClass.methods.any { MetaMethod it -> it.name == getter && it.parameterTypes.size() == 0 }) {
             LOG.warn "The $dc.clazz.name domain class has a method '$getter' - unable to add namespaced methods for datasource '$datasourceName'"
             return
         }
@@ -242,11 +259,11 @@ class HibernateUtils {
 
         def finders = HibernateGormEnhancer.createPersistentMethods(application, classLoader, datastore)
         def staticApi = new HibernateGormStaticApi(dc.clazz, datastore, finders, classLoader, transactionManager)
-        dc.metaClass.static."$getter" = { -> staticApi }
+        ((GroovyObject)((GroovyObject)dc.metaClass).getProperty('static')).setProperty(getter, { -> staticApi })
 
         def validateApi = new HibernateGormValidationApi(dc.clazz, datastore, classLoader)
         def instanceApi = new HibernateGormInstanceApi(dc.clazz, datastore, classLoader)
-        dc.metaClass."$getter" = { -> new InstanceProxy(delegate, instanceApi, validateApi) }
+        ((GroovyObject)dc.metaClass).setProperty(getter, { -> new InstanceProxy(getDelegate(), instanceApi, validateApi) })
     }
 
     /**
@@ -285,23 +302,41 @@ class HibernateUtils {
      * @return the idValue parameter converted to the type that grailsDomainClass expects
      * its identifiers to be
      */
-    static convertValueToIdentifierType(grailsDomainClass, idValue) {
-        convertToType(idValue, grailsDomainClass.identifier.type)
+    static Object convertValueToIdentifierType(GrailsDomainClass grailsDomainClass, Object idValue) {
+        convertValueToType(idValue, grailsDomainClass.identifier.type)
     }
-
-    private static convertToType(value, targetType) {
-        SimpleTypeConverter typeConverter = new SimpleTypeConverter()
-
-        if (value != null && !targetType.isAssignableFrom(value.getClass())) {
-            if (value instanceof Number && Long.equals(targetType)) {
-                value = value.toLong()
-            }
-            else {
-                try {
-                    value = typeConverter.convertIfNecessary(value, targetType)
-                } catch (TypeMismatchException e) {
-                    // ignore
+    
+    static Object convertValueToType(Object passedValue, Class targetType) {
+        // workaround for GROOVY-6127, do not assign directly in parameters before it's fixed
+        Object value = passedValue
+        if(targetType != null && value != null && !(value in targetType)) {
+            if (value instanceof CharSequence) {
+                value = value.toString()
+                if(value in targetType) {
+                    return value
                 }
+            }
+            try {
+                if (value instanceof Number && (targetType==Long || targetType==Integer)) {
+                    if(targetType == Long) {
+                        value = ((Number)value).toLong()
+                    } else {
+                        value = ((Number)value).toInteger()
+                    }
+                } else if (value instanceof String && targetType in Number) {
+                    String strValue = value.trim()
+                    if(targetType == Long) {
+                        value = Long.parseLong(strValue)
+                    } else if (targetType == Integer) {
+                        value = Integer.parseInt(strValue)
+                    } else {
+                        value = StringGroovyMethods.asType(strValue, targetType)
+                    }
+                } else {
+                    value = new SimpleTypeConverter().convertIfNecessary(value, targetType)
+                }
+            } catch (e) {
+                // ignore
             }
         }
         return value

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/InstanceProxy.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/InstanceProxy.groovy
@@ -15,9 +15,12 @@
  */
 package org.codehaus.groovy.grails.orm.hibernate.cfg
 
+import groovy.transform.CompileStatic;
+
 import org.codehaus.groovy.grails.orm.hibernate.HibernateGormInstanceApi
 import org.codehaus.groovy.grails.orm.hibernate.HibernateGormValidationApi
 
+@CompileStatic
 class InstanceProxy {
     private instance
     private HibernateGormValidationApi validateApi
@@ -29,7 +32,7 @@ class InstanceProxy {
         this.instance = instance
         this.instanceApi = instanceApi
         this.validateApi = validateApi
-        validateMethods = validateApi.methods*.name
+        validateMethods = validateApi.methods*.name as Set<String>
         validateMethods.remove 'getValidator'
         validateMethods.remove 'setValidator'
         validateMethods.remove 'getBeforeValidateHelper'
@@ -40,26 +43,26 @@ class InstanceProxy {
 
     def invokeMethod(String name, args) {
         if (validateMethods.contains(name)) {
-            validateApi."$name"(instance, *args)
+            validateApi.invokeMethod(name, [instance, *args])
         }
         else {
-            instanceApi."$name"(instance, *args)
+            instanceApi.invokeMethod(name, [instance, *args])
         }
     }
 
     void setProperty(String name, val) {
-        instanceApi."$name" = val
+        instanceApi.setProperty("$name", val)
     }
 
     def getProperty(String name) {
-        instanceApi."$name"
+        instanceApi.getProperty(name)
     }
 
     void putAt(String name, val) {
-        instanceApi."$name" = val
+        instanceApi.setProperty(name, val)
     }
 
     def getAt(String name) {
-        instanceApi."$name"
+        instanceApi.getProperty(name)
     }
 }


### PR DESCRIPTION
I made a patch after commit 114b02 of changes in hibernate3 module and applied the changes to hibernate4 module:

`git diff 114b02...master ../grails-datastore-gorm-hibernate | sed -e 's/hibernate3/hibernate4/g' | patch -p2 -f`

I tried to fix the conflicts in the correct way. I was wondering that hibernate4 module has it's own HibernateTemplate implementation. I hope the changes are ok that I made there. It contains the changes for GRAILS-10063 and GRAILS-10064.
