### PR TITLE
GRAILS-9773 - Fix HibernatePersistenceContextInterceptor usages with multiple datasources

### DIFF
--- a/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
@@ -39,7 +39,10 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
     private static final Log LOG = LogFactory.getLog(HibernatePersistenceContextInterceptor.class);
     private SessionFactory sessionFactory;
 
-    static {
+    private ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>();
+    private ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>();
+
+    public HibernatePersistenceContextInterceptor() {
         ShutdownOperations.addOperation(new Runnable() {
             public void run() {
                 participate.remove();
@@ -47,9 +50,6 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
             }
         });
     }
-
-    private static ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>();
-    private static ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>();
 
     /* (non-Javadoc)
      * @see org.codehaus.groovy.grails.support.PersistenceContextInterceptor#destroy()

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
@@ -42,7 +42,10 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
     private static final Log LOG = LogFactory.getLog(HibernatePersistenceContextInterceptor.class);
     private SessionFactory sessionFactory;
 
-    static {
+    private ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>();
+    private ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>();
+
+    public HibernatePersistenceContextInterceptor() {
         ShutdownOperations.addOperation(new Runnable() {
             public void run() {
                 participate.remove();
@@ -50,9 +53,6 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
             }
         });
     }
-
-    private static ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>();
-    private static ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>();
 
     /* (non-Javadoc)
      * @see org.codehaus.groovy.grails.support.PersistenceContextInterceptor#destroy()


### PR DESCRIPTION
`HibernatePersistenceContextInterceptor` uses a static `ThreadLocal` to manage nesting, but `AggregatePersistenceContextInterceptor` creates one `HibernatePersistenceContextInterceptor` per datasource so the wrong behavior occurs on `init()` and especially `destroy()`. Since `HibernatePersistenceContextInterceptor` is essentially a singleton per datasource it's safe (and proper in this case) to use a local ThreadLocal on `HibernatePersistenceContextInterceptor`.
