### PR TITLE
GRAILS-10162 - Don't NPE if trying to initialize a collection for which ...

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/AbstractPersistentCollection.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/AbstractPersistentCollection.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.grails.datastore.mapping.core.Session;
 import org.grails.datastore.mapping.engine.AssociationIndexer;
+import org.grails.datastore.mapping.model.PersistentEntity;
 
 /**
  * Abstract base class for persistent collections.
@@ -203,7 +204,14 @@ public abstract class AbstractPersistentCollection implements PersistentCollecti
         }
         else {
             List results = indexer.query(associationKey);
-            addAll(session.retrieveAll(indexer.getIndexedEntity().getJavaClass(), results));
+            PersistentEntity entity = indexer.getIndexedEntity();
+
+            // This should really only happen for unit testing since entities are
+            // mocked selectively and may not always be registered in the indexer. In this
+            // case, there can't be any results to be added to the collection.
+            if( entity != null ) {
+                addAll(session.retrieveAll(entity.getJavaClass(), results));
+            }
         }
     }
 

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/JavassistProxyFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/JavassistProxyFactory.java
@@ -106,7 +106,16 @@ public class JavassistProxyFactory implements org.grails.datastore.mapping.proxy
                         return target;
                     }
                 }
-                if (target == null) initialize();
+                if (target == null) {
+                    initialize();
+
+                    // This tends to happen during unit testing if the proxy class is not properly mocked
+                    // and therefore can't be found in the session.
+                    if( target == null ) {
+                        throw new IllegalStateException("Proxy for ["+cls.getName()+":"+id+"] could not be initialized");
+                    }
+                }
+
                 return org.springframework.util.ReflectionUtils.invokeMethod(method, target, args);
             }
 


### PR DESCRIPTION
...the indexer can't find the entity; better proxy initialization error messages.

Two changes:
1. If a collection is being initialized and the indexer doesn't know the entity, it is almost certainly the case that it's a unit test and it isn't mocked. In that case, there can't be any objects of that type so just don't try to add any results.
2. Another case where a proxy is trying to be unwrapped and the map doesn't have that entity, just provide a better error message instead of NPE.
