### PR TITLE
GRAILS-10505 - GORM in-memory implementation behaves differently from hi...

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/grails/gorm/CriteriaBuilder.java
+++ b/grails-datastore-gorm/src/main/groovy/grails/gorm/CriteriaBuilder.java
@@ -986,7 +986,9 @@ public class CriteriaBuilder extends GroovyObjectSupport implements Criteria, Pr
             }
         } finally {
             Query.Junction logicalExpression = logicalExpressionStack.remove(logicalExpressionStack.size()-1);
-            addToCriteria(logicalExpression);
+            if (!logicalExpression.isEmpty()) {
+                addToCriteria(logicalExpression);
+            }
         }
     }
 


### PR DESCRIPTION
...bernate implementation when using criteria with empty junctions

This fix makes CriteriaBuilder ignore empty junctions
