### PR TITLE
GPMONGODB-325: Fix the broken link for developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Getting Started
 ---
 
 For further information on the project see the comprehensive [developer guide][Developer Guide].
-[Developer Guide]: http://springsource.github.com/grails-data-mapping/
+[Developer Guide]: http://projects.spring.io/grails-data-mapping/manual/index.html
 	
 License
 ---


### PR DESCRIPTION
This fixes broken link on github. However, not sure on where is the content loaded for http://grails.org/plugin/mongodb to fix the "further documentation" link.
