### PR TITLE
Made testing gorm-rest-client example a full integration test

### DIFF
--- a/grails-documentation-rest-client/src/docs/guide/6. Testing.gdoc
+++ b/grails-documentation-rest-client/src/docs/guide/6. Testing.gdoc
@@ -1,12 +1,42 @@
-GORM for REST uses Spring's RestTemplate under the covers, so testing can be done with Spring's [MockRestServiceServer|http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/test/web/client/MockRestServiceServer.html] API. Example:
+GORM for REST uses Spring's RestTemplate under the covers, so testing can be done with Spring's [MockRestServiceServer|http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/test/web/client/MockRestServiceServer.html] API. 
+
+Here is an example integration test:
 
 {code}
-    RestTemplate rt = Book.getRestBuilder().restTemplate
-    final mockServer = MockRestServiceServer.createServer(rt)
-    mockServer.expect(requestTo("http://localhost:8080/book"))
-            .andExpect(method(HttpMethod.GET))
-            .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
-            .andRespond(withSuccess('[{"id":1, "title":"The Stand", "pages":200}]', MediaType.APPLICATION_JSON))
 
-    List results = Book.list()
+package amazon.client
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.web.client.RestTemplate
+
+import grails.test.spock.IntegrationSpec
+
+class BookSpec extends IntegrationSpec {
+
+    void 'Book list returns correct number of books'() {
+        given:
+        RestTemplate rt = Book.restBuilder.restTemplate
+        final MockRestServiceServer mockServer = MockRestServiceServer.createServer(rt)
+        mockServer.expect(requestTo("http://localhost:8080/amazon/books"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess('[{"id":1, "title":"The Stand", "pages":200}]', MediaType.APPLICATION_JSON))
+
+        when:
+        List results = Book.list()
+
+        then:
+        results.size() == 1
+    }
+
+}
+
 {code}


### PR DESCRIPTION
I had trouble following the example provided in the documentation.

One particular issue was that imports were missing, so I had to go back to the gorm tests to see the static imports actually being used to refer to requestTo.

The suggested changes work with the provided example in the other sections of the manual.
