### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     repositories {
         mavenRepo name:'mavenLocal',
                   urls:new File(System.getProperty("user.home"), ".m2/repository").toURL().toString()
-        mavenRepo(urls: "http://repo.grails.org/grails/core") {
+        mavenRepo(urls: "https://repo.grails.org/grails/core") {
             if (project.hasProperty('snapshotTimeout')) {
                 setSnapshotTimeout(Long.parseLong(project.snapshotTimeout))
             }
@@ -124,8 +124,8 @@ subprojects {
                 licenses {
                     license {
                         name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'http://github.com/SpringSource/grails-data-mapping/'
+                        url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution 'https://github.com/SpringSource/grails-data-mapping/'
                     }
                 }
             }
@@ -133,8 +133,8 @@ subprojects {
 
         uploadArchives {
             description = "Does a maven deploy of archives artifacts"
-            def milestoneRepositoryUrl = "http://repo.grails.org/grails/libs-releases-local"
-            def snapshotRepositoryUrl = "http://repo.grails.org/grails/libs-snapshots-local"
+            def milestoneRepositoryUrl = "https://repo.grails.org/grails/libs-releases-local"
+            def snapshotRepositoryUrl = "https://repo.grails.org/grails/libs-snapshots-local"
 
             // add a configuration with a classpath that includes our s3 maven deployer
             configurations { deployerJars }
@@ -175,7 +175,7 @@ subprojects {
                     licenses {
                         license {
                             name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                             distribution 'repo'
                         }
                     }

--- a/grails-datastore-appengine/build.gradle
+++ b/grails-datastore-appengine/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    mavenRepo urls:'http://maven-gae-plugin.googlecode.com/svn/repository/'
+    mavenRepo urls:'https://maven-gae-plugin.googlecode.com/svn/repository/'
 }
 
 dependencies {

--- a/grails-datastore-cassandra/build.gradle
+++ b/grails-datastore-cassandra/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    mavenRepo urls:'http://eaio.com/maven2'
+    mavenRepo urls:'https://eaio.com/maven2'
 }
 
 dependencies {

--- a/grails-datastore-gorm-neo4j/build.gradle
+++ b/grails-datastore-gorm-neo4j/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    mavenRepo urls:'http://m2.neo4j.org/'
+    mavenRepo urls:'https://m2.neo4j.org/'
 }
 
 dependencies {

--- a/grails-documentation-redis/build.gradle
+++ b/grails-documentation-redis/build.gradle
@@ -21,7 +21,7 @@ else {
         classpath = files(groovyProjects().collect { project ->
             [project.sourceSets.main.compileClasspath, project.sourceSets.main.classes]
         })
-        options.links("http://download.oracle.com/javase/6/docs/api/", "http://groovy.codehaus.org/gapi/")
+        options.links("https://download.oracle.com/javase/6/docs/api/", "https://groovy.codehaus.org/gapi/")
         doFirst {
             title = "Datastore API $version"
         }

--- a/grails-documentation-riak/build.gradle
+++ b/grails-documentation-riak/build.gradle
@@ -23,7 +23,7 @@ if (Boolean.getBoolean("skip.javadoc")) {
         classpath = files(groovyProjects().collect { project ->
             [project.sourceSets.main.compileClasspath, project.sourceSets.main.classes]
         })
-        options.links("http://download.oracle.com/javase/6/docs/api/", "http://groovy.codehaus.org/gapi/")
+        options.links("https://download.oracle.com/javase/6/docs/api/", "https://groovy.codehaus.org/gapi/")
         doFirst {
             title = "Datastore API $version"
         }

--- a/grails-plugins/redis/build.gradle
+++ b/grails-plugins/redis/build.gradle
@@ -2,7 +2,7 @@ buildscript {
 
     repositories {
         mavenCentral()
-        mavenRepo urls: "http://repo.grails.org/grails/core"
+        mavenRepo urls: "https://repo.grails.org/grails/core"
     }
 
     dependencies {
@@ -25,7 +25,7 @@ configurations {
 }
 
 repositories {
-    mavenRepo urls:"http://repository.codehaus.org/"
+    mavenRepo urls:"https://repository.codehaus.org/"
 }
 
 dependencies {

--- a/grails-plugins/riak/build.gradle
+++ b/grails-plugins/riak/build.gradle
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@
 buildscript {
   repositories {
     mavenCentral()
-    mavenRepo urls: "http://repository.jboss.org/maven2/"
+    mavenRepo urls: "https://repository.jboss.org/maven2/"
   }
   dependencies {
     classpath "org.grails:grails-gradle-plugin:1.0", "org.grails:grails-bootstrap:1.3.6"
@@ -40,7 +40,7 @@ configurations {
 }
 
 repositories {
-  mavenRepo urls: "http://repository.codehaus.org/"
+  mavenRepo urls: "https://repository.codehaus.org/"
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://dist.gemstone.com/maven/release (404) with 1 occurrences could not be migrated:  
   ([https](https://dist.gemstone.com/maven/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://groovy.codehaus.org/gapi/ (UnknownHostException) with 2 occurrences migrated to:  
  https://groovy.codehaus.org/gapi/ ([https](https://groovy.codehaus.org/gapi/) result UnknownHostException).
* http://repository.codehaus.org/ (UnknownHostException) with 2 occurrences migrated to:  
  https://repository.codehaus.org/ ([https](https://repository.codehaus.org/) result UnknownHostException).
* http://maven-gae-plugin.googlecode.com/svn/repository/ (404) with 1 occurrences migrated to:  
  https://maven-gae-plugin.googlecode.com/svn/repository/ ([https](https://maven-gae-plugin.googlecode.com/svn/repository/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/SpringSource/grails-data-mapping/ with 1 occurrences migrated to:  
  https://github.com/SpringSource/grails-data-mapping/ ([https](https://github.com/SpringSource/grails-data-mapping/) result 200).
* http://repository.jboss.org/maven2/ with 1 occurrences migrated to:  
  https://repository.jboss.org/maven2/ ([https](https://repository.jboss.org/maven2/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://eaio.com/maven2 with 1 occurrences migrated to:  
  https://eaio.com/maven2 ([https](https://eaio.com/maven2) result 301).
* http://m2.neo4j.org/ with 1 occurrences migrated to:  
  https://m2.neo4j.org/ ([https](https://m2.neo4j.org/) result 301).
* http://download.oracle.com/javase/6/docs/api/ with 2 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api/ ([https](https://download.oracle.com/javase/6/docs/api/) result 302).
* http://repo.grails.org/grails/core with 2 occurrences migrated to:  
  https://repo.grails.org/grails/core ([https](https://repo.grails.org/grails/core) result 302).
* http://repo.grails.org/grails/libs-releases-local with 1 occurrences migrated to:  
  https://repo.grails.org/grails/libs-releases-local ([https](https://repo.grails.org/grails/libs-releases-local) result 302).
* http://repo.grails.org/grails/libs-snapshots-local with 1 occurrences migrated to:  
  https://repo.grails.org/grails/libs-snapshots-local ([https](https://repo.grails.org/grails/libs-snapshots-local) result 302).