### PR TITLE
URL Cleanup

### DIFF
--- a/grails-datastore-appengine/src/main/java/org/grails/datastore/mapping/appengine/engine/AppEngineEntityPersister.java
+++ b/grails-datastore-appengine/src/main/java/org/grails/datastore/mapping/appengine/engine/AppEngineEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/CassandraDatastore.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/CassandraDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/CassandraSession.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/CassandraSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/engine/CassandraAssociationIndexer.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/engine/CassandraAssociationIndexer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/engine/CassandraEntityPersister.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/engine/CassandraEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/util/HectorCallback.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/util/HectorCallback.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/util/HectorTemplate.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/util/HectorTemplate.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/uuid/UUIDUtil.java
+++ b/grails-datastore-cassandra/src/main/java/org/grails/datastore/mapping/cassandra/uuid/UUIDUtil.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/test/resources/cassandra-conf/log4j.properties
+++ b/grails-datastore-cassandra/src/test/resources/cassandra-conf/log4j.properties
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-cassandra/src/test/resources/cassandra-conf/storage-conf.xml
+++ b/grails-datastore-cassandra/src/test/resources/cassandra-conf/storage-conf.xml
@@ -7,7 +7,7 @@
  ~ "License"); you may not use this file except in compliance
  ~ with the License.  You may obtain a copy of the License at
  ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~    https://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing,
  ~ software distributed under the License is distributed on an

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/AbstractPersistentCollection.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/AbstractPersistentCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentCollection.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentList.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentList.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentSet.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/collection/PersistentSet.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/column/ColumnDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/column/ColumnDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/AbstractGormMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/AbstractGormMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Property.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Property.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/groovy/MappingConfigurationBuilder.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/groovy/MappingConfigurationBuilder.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/utils/ConfigUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/utils/ConfigUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractAttributeStoringSession.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractAttributeStoringSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractSession.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/ConnectionNotFoundException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/ConnectionNotFoundException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/Datastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/Datastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreAware.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreAware.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/EntityCreationException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/EntityCreationException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/OptimisticLockingException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/OptimisticLockingException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/Session.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/Session.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SessionCallback.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SessionCallback.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SessionImplementor.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SessionImplementor.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/VoidSessionCallback.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/VoidSessionCallback.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingInsert.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingInsert.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingInsertAdapter.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingInsertAdapter.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperation.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperation.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperationAdapter.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperationAdapter.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperationExecution.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingOperationExecution.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingUpdate.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingUpdate.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingUpdateAdapter.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/impl/PendingUpdateAdapter.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/DocumentDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/DocumentDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/Attribute.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/Attribute.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/Collection.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/Collection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/DocumentMappingContext.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/DocumentMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/DocumentPersistentEntity.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/DocumentPersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/GormDocumentMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/document/config/GormDocumentMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/AssociationIndexer.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/AssociationIndexer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityAccess.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityAccess.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/EntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/LockableEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/LockableEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NativeEntryEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NonPersistentTypeException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/NonPersistentTypeException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/Persister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/Persister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/PropertyValueIndexer.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/PropertyValueIndexer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/AbstractPersistenceEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/AbstractPersistenceEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/AbstractPersistenceEventListener.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/AbstractPersistenceEventListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PersistenceEventListener.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PersistenceEventListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostDeleteEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostDeleteEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostInsertEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostInsertEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostLoadEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostLoadEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostUpdateEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PostUpdateEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreDeleteEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreDeleteEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreInsertEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreInsertEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreLoadEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreLoadEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreUpdateEvent.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/engine/event/PreUpdateEvent.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/graph/GraphDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/graph/GraphDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/engine/AbstractKeyValueEntityPersister.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/engine/AbstractKeyValueEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/engine/KeyValueEntry.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/engine/KeyValueEntry.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/AnnotationKeyValueMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/AnnotationKeyValueMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/Family.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/Family.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/GormKeyValueMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/GormKeyValueMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValue.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValue.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValueMappingContext.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValueMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValueMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValueMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValuePersistentEntity.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/KeyValuePersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractClassMapping.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractClassMapping.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractMappingContext.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractPersistentEntity.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractPersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractPersistentProperty.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/AbstractPersistentProperty.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/ClassMapping.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/ClassMapping.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/DatastoreConfigurationException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/DatastoreConfigurationException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/IdentityMapping.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/IdentityMapping.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/IllegalMappingException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/IllegalMappingException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingContext.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/DefaultMappingConfigurationStrategy.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/DefaultMappingConfigurationStrategy.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/GormMappingConfigurationStrategy.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/GormMappingConfigurationStrategy.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/GormProperties.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/config/GormProperties.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Association.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Association.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Basic.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Basic.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/BasicTypeConverterRegistrar.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/BasicTypeConverterRegistrar.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Embedded.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Embedded.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/EmbeddedCollection.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/EmbeddedCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Identity.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Identity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ManyToMany.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ManyToMany.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ManyToOne.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ManyToOne.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/OneToMany.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/OneToMany.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/OneToOne.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/OneToOne.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Simple.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/Simple.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ToOne.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/types/ToOne.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/EntityProxy.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/EntityProxy.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/JavassistProxyFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/JavassistProxyFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/ProxyFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/proxy/ProxyFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/AssociationQuery.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/AssociationQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Projections.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Projections.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Query.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Query.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Restrictions.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Restrictions.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/order/ManualEntityOrdering.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/order/ManualEntityOrdering.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/projections/ManualProjections.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/projections/ManualProjections.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/rdbms/RelationalDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/rdbms/RelationalDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcher.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcher.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/InstantiationException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/InstantiationException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/NameUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/NameUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ReflectionUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ReflectionUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/DatastoreTransactionManager.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/DatastoreTransactionManager.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/SessionHolder.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/SessionHolder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/SessionOnlyTransaction.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/SessionOnlyTransaction.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/Transaction.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/Transaction.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/TransactionObject.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/TransactionObject.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/TransactionUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/TransactionUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/support/SpringSessionSynchronization.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/support/SpringSessionSynchronization.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/validation/ValidatingEventListener.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/validation/ValidatingEventListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/validation/ValidationException.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/validation/ValidationException.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/GemfireDatastore.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/GemfireDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/GemfireSession.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/GemfireSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/config/GormGemfireMappingFactory.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/config/GormGemfireMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/config/Region.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/config/Region.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/engine/GemfireEntityPersister.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/engine/GemfireEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/query/GemfireQuery.java
+++ b/grails-datastore-gemfire/src/main/groovy/org/grails/datastore/mapping/gemfire/query/GemfireQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/ContinuousQueryApi.groovy
+++ b/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/ContinuousQueryApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/GemfireGormEnhancer.groovy
+++ b/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/GemfireGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/config/CacheServerConfigGenerator.groovy
+++ b/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/config/CacheServerConfigGenerator.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/config/PoolFactoryBean.groovy
+++ b/grails-datastore-gorm-gemfire/src/main/groovy/org/grails/datastore/gorm/gemfire/config/PoolFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jcr/src/main/groovy/org/grails/datastore/gorm/jcr/JcrGormEnhancer.groovy
+++ b/grails-datastore-gorm-jcr/src/main/groovy/org/grails/datastore/gorm/jcr/JcrGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/EntityInterceptorInvokingEntityListener.java
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/EntityInterceptorInvokingEntityListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/GormToJpaTransform.java
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/GormToJpaTransform.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/JpaGormEnhancer.groovy
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/JpaGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/bean/factory/JpaDatastoreFactoryBean.groovy
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/bean/factory/JpaDatastoreFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/bean/factory/JpaMappingContextFactoryBean.groovy
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/bean/factory/JpaMappingContextFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/support/JpaOpenSessionInViewInterceptor.java
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/support/JpaOpenSessionInViewInterceptor.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/support/JpaPersistenceContextInterceptor.java
+++ b/grails-datastore-gorm-jpa/src/main/groovy/org/grails/datastore/gorm/jpa/support/JpaPersistenceContextInterceptor.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/MongoCriteriaBuilder.java
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/MongoCriteriaBuilder.java
@@ -4,7 +4,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/MongoGormEnhancer.groovy
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/MongoGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/Near.java
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/Near.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/WithinBox.java
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/WithinBox.java
@@ -4,7 +4,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/WithinCircle.java
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/WithinCircle.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/GMongoFactoryBean.java
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/GMongoFactoryBean.java
@@ -4,7 +4,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/MongoDatastoreFactoryBean.groovy
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/MongoDatastoreFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/MongoMappingContextFactoryBean.groovy
+++ b/grails-datastore-gorm-mongo/src/main/groovy/org/grails/datastore/gorm/mongo/bean/factory/MongoMappingContextFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GrailsRelationshipTypes.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GrailsRelationshipTypes.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GraphGormMappingFactory.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GraphGormMappingFactory.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GraphPersistentEntity.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/GraphPersistentEntity.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jAssociationIndexer.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jAssociationIndexer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jDatastore.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jDatastore.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jEntityAccess.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jEntityAccess.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jEntityPersister.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jEntityPersister.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jGormEnhancer.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jMappingContext.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jMappingContext.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jOpenSessionInViewInterceptor.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jOpenSessionInViewInterceptor.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jPropertyValueIndexer.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jPropertyValueIndexer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jQuery.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jQuery.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jSession.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jTransaction.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jTransaction.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/bean/factory/Neo4jDatastoreFactoryBean.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/bean/factory/Neo4jDatastoreFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/bean/factory/Neo4jMappingContextFactoryBean.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/bean/factory/Neo4jMappingContextFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/constraints/UniqueConstraint.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/constraints/UniqueConstraint.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToBigDecimalConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToBigDecimalConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToBigIntegerConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToBigIntegerConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToCurrencyConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToCurrencyConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToLocaleConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToLocaleConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToShortConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToShortConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToTimeZoneConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToTimeZoneConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToURLConverter.groovy
+++ b/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/converters/StringToURLConverter.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-redis/src/main/groovy/grails/datastore/Redis.groovy
+++ b/grails-datastore-gorm-redis/src/main/groovy/grails/datastore/Redis.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-redis/src/main/groovy/org/grails/datastore/gorm/redis/RedisGormEnhancer.groovy
+++ b/grails-datastore-gorm-redis/src/main/groovy/org/grails/datastore/gorm/redis/RedisGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakDatastoreFactoryBean.groovy
+++ b/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakDatastoreFactoryBean.groovy
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakGormEnhancer.groovy
+++ b/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakGormEnhancer.groovy
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakMappingContextFactoryBean.groovy
+++ b/grails-datastore-gorm-riak/src/main/groovy/org/grails/datastore/gorm/riak/RiakMappingContextFactoryBean.groovy
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-riak/src/test/groovy/org/grails/datastore/gorm/Setup.groovy
+++ b/grails-datastore-gorm-riak/src/test/groovy/org/grails/datastore/gorm/Setup.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/SimpleDBCriteriaBuilder.java
+++ b/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/SimpleDBCriteriaBuilder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/SimpleDBGormEnhancer.groovy
+++ b/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/SimpleDBGormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/bean/factory/SimpleDBDatastoreFactoryBean.groovy
+++ b/grails-datastore-gorm-simpledb/src/main/groovy/org/grails/datastore/gorm/simpledb/bean/factory/SimpleDBDatastoreFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm-test/src/main/groovy/grails/datastore/test/DatastoreUnitTestMixin.groovy
+++ b/grails-datastore-gorm-test/src/main/groovy/grails/datastore/test/DatastoreUnitTestMixin.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/grails/gorm/CriteriaBuilder.java
+++ b/grails-datastore-gorm/src/main/groovy/grails/gorm/CriteriaBuilder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/AbstractDatastoreApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/AbstractDatastoreApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/AbstractGormApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/AbstractGormApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormInstanceApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormInstanceApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormStaticApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormStaticApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidationApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidationApi.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bean/factory/AbstractMappingContextFactoryBean.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bean/factory/AbstractMappingContextFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassMappingContext.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassPersistentEntity.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassPersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassPersistentProperty.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassPersistentProperty.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/DomainEventListener.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/DomainEventListener.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/AbstractFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/AbstractFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinderInvocation.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinderInvocation.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByBooleanFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByBooleanFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindByBooleanFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindByBooleanFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindOrCreateByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindOrCreateByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindOrSaveByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindOrSaveByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FinderMethod.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FinderMethod.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/ListOrderByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/ListOrderByFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/MethodExpression.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/MethodExpression.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/QueryBuildingFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/QueryBuildingFinder.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactory.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactory.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/query/NamedQueriesBuilder.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/query/NamedQueriesBuilder.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/BeforeValidateHelper.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/BeforeValidateHelper.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/DatastorePersistenceContextInterceptor.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/DatastorePersistenceContextInterceptor.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/InstanceProxy.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/InstanceProxy.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/ReflectionUtils.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/ReflectionUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/test/resources/cassandra-conf/log4j.properties
+++ b/grails-datastore-gorm/src/test/resources/cassandra-conf/log4j.properties
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-gorm/src/test/resources/cassandra-conf/storage-conf.xml
+++ b/grails-datastore-gorm/src/test/resources/cassandra-conf/storage-conf.xml
@@ -7,7 +7,7 @@
  ~ "License"); you may not use this file except in compliance
  ~ with the License.  You may obtain a copy of the License at
  ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~    https://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing,
  ~ software distributed under the License is distributed on an

--- a/grails-datastore-jcr/repository.xml
+++ b/grails-datastore-jcr/repository.xml
@@ -7,7 +7,7 @@
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jcr/src/main/java/org/grails/datastore/mapping/jcr/JcrSession.java
+++ b/grails-datastore-jcr/src/main/java/org/grails/datastore/mapping/jcr/JcrSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jcr/src/test/resources/log4j.properties
+++ b/grails-datastore-jcr/src/test/resources/log4j.properties
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/JpaDatastore.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/JpaDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/JpaSession.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/JpaSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingConfigurationStrategy.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingConfigurationStrategy.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingContext.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingFactory.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaPersistentEntity.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/config/JpaPersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/query/JpaQuery.java
+++ b/grails-datastore-jpa/src/main/groovy/org/grails/datastore/mapping/jpa/query/JpaQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/MongoSession.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/MongoSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoAttribute.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoAttribute.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoCollection.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoMappingContext.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/config/MongoMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/engine/MongoEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/query/MongoQuery.java
+++ b/grails-datastore-mongo/src/main/groovy/org/grails/datastore/mapping/mongo/query/MongoQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisDatastore.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisEntry.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisEntry.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisSession.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisTransaction.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/RedisTransaction.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/AbstractRedisCollection.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/AbstractRedisCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisCollection.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisCollection.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisList.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisList.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisMap.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisMap.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisSet.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisSet.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisValue.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/collection/RedisValue.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisAssociationIndexer.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisAssociationIndexer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisEntityPersister.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisPropertyValueIndexer.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/engine/RedisPropertyValueIndexer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/query/RedisQuery.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/query/RedisQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/query/RedisQueryUtils.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/query/RedisQueryUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/JedisTemplate.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/JedisTemplate.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/RedisCallback.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/RedisCallback.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/RedisTemplate.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/RedisTemplate.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/SortParams.java
+++ b/grails-datastore-redis/src/main/java/org/grails/datastore/mapping/redis/util/SortParams.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakDatastore.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakDatastore.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakEntry.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakEntry.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakSession.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakSession.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakTransaction.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/RiakTransaction.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/AbstractRiakCollection.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/AbstractRiakCollection.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakCollection.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakCollection.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakEntityIndex.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakEntityIndex.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakList.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/collection/RiakList.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakAssociationIndexer.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakAssociationIndexer.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakEntityPersister.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakEntityPersister.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakPropertyValueIndexer.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/engine/RiakPropertyValueIndexer.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/query/RiakQuery.groovy
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/query/RiakQuery.groovy
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/util/Ignore404sErrorHandler.java
+++ b/grails-datastore-riak/src/main/groovy/org/grails/datastore/mapping/riak/util/Ignore404sErrorHandler.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/SimpleMapDatastore.java
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/SimpleMapDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/SimpleMapSession.java
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/SimpleMapSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/query/SimpleMapQuery.groovy
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/query/SimpleMapQuery.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/SimpleDBDatastore.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/SimpleDBDatastore.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/SimpleDBSession.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/SimpleDBSession.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/GormSimpleDBMappingFactory.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/GormSimpleDBMappingFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBDomainClassMappedForm.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBDomainClassMappedForm.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBMappingContext.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBMappingContext.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBPersistentEntity.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/config/SimpleDBPersistentEntity.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/AbstractSimpleDBDomainResolver.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/AbstractSimpleDBDomainResolver.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/ConstSimpleDBDomainResolver.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/ConstSimpleDBDomainResolver.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/NativeSimpleDBItem.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/NativeSimpleDBItem.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBDomainResolver.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBDomainResolver.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBDomainResolverFactory.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBDomainResolverFactory.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBEntityPersister.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/engine/SimpleDBEntityPersister.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/model/types/SimpleDBTypeConverterRegistrar.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/model/types/SimpleDBTypeConverterRegistrar.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/query/SimpleDBQuery.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/query/SimpleDBQuery.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/DelayAfterWriteSimpleDBTemplateDecorator.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/DelayAfterWriteSimpleDBTemplateDecorator.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBConst.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBConst.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBTemplate.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBTemplate.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBTemplateImpl.java
+++ b/grails-datastore-simpledb/src/main/groovy/org/grails/datastore/mapping/simpledb/util/SimpleDBTemplateImpl.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-datastore-web/src/main/groovy/org/grails/datastore/mapping/web/support/OpenSessionInViewInterceptor.java
+++ b/grails-datastore-web/src/main/groovy/org/grails/datastore/mapping/web/support/OpenSessionInViewInterceptor.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/mongodb/LICENSE
+++ b/grails-plugins/mongodb/LICENSE
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/mongodb/src/groovy/org/grails/plugin/mongo/AggregatePersistenceContextInterceptor.java
+++ b/grails-plugins/mongodb/src/groovy/org/grails/plugin/mongo/AggregatePersistenceContextInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/mongodb/src/groovy/org/grails/plugin/mongo/PersistenceContextInterceptorAggregator.groovy
+++ b/grails-plugins/mongodb/src/groovy/org/grails/plugin/mongo/PersistenceContextInterceptorAggregator.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/LICENSE
+++ b/grails-plugins/redis/LICENSE
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/RedisGormGrailsPlugin.groovy
+++ b/grails-plugins/redis/RedisGormGrailsPlugin.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/src/groovy/org/grails/plugins/redis/AggregatePersistenceContextInterceptor.java
+++ b/grails-plugins/redis/src/groovy/org/grails/plugins/redis/AggregatePersistenceContextInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/src/groovy/org/grails/plugins/redis/PersistenceContextInterceptorAggregator.groovy
+++ b/grails-plugins/redis/src/groovy/org/grails/plugins/redis/PersistenceContextInterceptorAggregator.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/src/groovy/org/grails/plugins/redis/RedisDatastoreFactoryBean.groovy
+++ b/grails-plugins/redis/src/groovy/org/grails/plugins/redis/RedisDatastoreFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/redis/src/groovy/org/grails/plugins/redis/RedisMappingContextFactoryBean.groovy
+++ b/grails-plugins/redis/src/groovy/org/grails/plugins/redis/RedisMappingContextFactoryBean.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/riak/RiakGrailsPlugin.groovy
+++ b/grails-plugins/riak/RiakGrailsPlugin.groovy
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/simpledb/src/groovy/org/grails/plugin/simpledb/AggregatePersistenceContextInterceptor.java
+++ b/grails-plugins/simpledb/src/groovy/org/grails/plugin/simpledb/AggregatePersistenceContextInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/grails-plugins/simpledb/src/groovy/org/grails/plugin/simpledb/PersistenceContextInterceptorAggregator.groovy
+++ b/grails-plugins/simpledb/src/groovy/org/grails/plugin/simpledb/PersistenceContextInterceptorAggregator.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 302 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).