### PR TITLE
URL Cleanup

### DIFF
--- a/grails-datastore-cassandra/src/test/resources/cassandra-conf/storage-conf.xml
+++ b/grails-datastore-cassandra/src/test/resources/cassandra-conf/storage-conf.xml
@@ -46,7 +46,7 @@
   <AutoBootstrap>false</AutoBootstrap>
 
   <!--
-   ~ See http://wiki.apache.org/cassandra/HintedHandoff
+   ~ See https://wiki.apache.org/cassandra/HintedHandoff
   -->
   <HintedHandoffEnabled>true</HintedHandoffEnabled>
 
@@ -309,7 +309,7 @@
   <!--
    ~ Size of compacted row above which to log a warning.  (If compacted
    ~ rows do not fit in memory, Cassandra will crash.  This is explained
-   ~ in http://wiki.apache.org/cassandra/CassandraLimitations and is
+   ~ in https://wiki.apache.org/cassandra/CassandraLimitations and is
    ~ scheduled to be fixed in 0.7.)
   -->
   <RowWarningThresholdInMB>512</RowWarningThresholdInMB>

--- a/grails-datastore-gorm/src/test/resources/cassandra-conf/storage-conf.xml
+++ b/grails-datastore-gorm/src/test/resources/cassandra-conf/storage-conf.xml
@@ -46,7 +46,7 @@
   <AutoBootstrap>false</AutoBootstrap>
 
   <!--
-   ~ See http://wiki.apache.org/cassandra/HintedHandoff
+   ~ See https://wiki.apache.org/cassandra/HintedHandoff
   -->
   <HintedHandoffEnabled>true</HintedHandoffEnabled>
 
@@ -281,7 +281,7 @@
   <!--
    ~ Size of compacted row above which to log a warning.  (If compacted
    ~ rows do not fit in memory, Cassandra will crash.  This is explained
-   ~ in http://wiki.apache.org/cassandra/CassandraLimitations and is
+   ~ in https://wiki.apache.org/cassandra/CassandraLimitations and is
    ~ scheduled to be fixed in 0.7.)
   -->
   <RowWarningThresholdInMB>512</RowWarningThresholdInMB>

--- a/grails-datastore-jcr/repository.xml
+++ b/grails-datastore-jcr/repository.xml
@@ -16,7 +16,7 @@
    limitations under the License.
 -->
 <!DOCTYPE Repository PUBLIC "-//The Apache Software Foundation//DTD Jackrabbit 1.6//EN"
-                            "http://jackrabbit.apache.org/dtd/repository-1.6.dtd">
+                            "https://jackrabbit.apache.org/dtd/repository-1.6.dtd">
 <!-- Example Repository Configuration File
      Used by
      - org.apache.jackrabbit.core.config.RepositoryConfigTest.java


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://jackrabbit.apache.org/dtd/repository-1.6.dtd with 1 occurrences migrated to:  
  https://jackrabbit.apache.org/dtd/repository-1.6.dtd ([https](https://jackrabbit.apache.org/dtd/repository-1.6.dtd) result 200).
* [ ] http://wiki.apache.org/cassandra/CassandraLimitations with 2 occurrences migrated to:  
  https://wiki.apache.org/cassandra/CassandraLimitations ([https](https://wiki.apache.org/cassandra/CassandraLimitations) result 200).
* [ ] http://wiki.apache.org/cassandra/HintedHandoff with 2 occurrences migrated to:  
  https://wiki.apache.org/cassandra/HintedHandoff ([https](https://wiki.apache.org/cassandra/HintedHandoff) result 200).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 1 occurrences